### PR TITLE
Improve Handling of Changed Scripts and Resuming

### DIFF
--- a/Private/Read-StepperState.ps1
+++ b/Private/Read-StepperState.ps1
@@ -11,7 +11,7 @@ function Read-StepperState {
         The path to the state file.
 
     .OUTPUTS
-        PSCustomObject or $null - The state object containing ScriptHash, LastCompletedStep, Timestamp, and StepperData
+        PSCustomObject or $null - The state object containing ScriptHash, ScriptContents, LastCompletedStep, Timestamp, and StepperData
     #>
     [CmdletBinding()]
     param(

--- a/Private/Show-MoreDetails.ps1
+++ b/Private/Show-MoreDetails.ps1
@@ -107,17 +107,19 @@ function Show-MoreDetails {
     $ns = [int]$NextStepLine
     $start2 = [Math]::Max(1, $ns - 2)
     $end2 = $ns + 3
-    $ln = 1
-    foreach ($line in (Get-Content -Path $ScriptPath)) {
-        if ($ln -ge $start2 -and $ln -le $end2) {
-            $display = ($line -replace "`t", "    ").TrimEnd()
-            if ($ln -eq $ns) {
-                Write-Host ("{0,5}: {1}" -f $ln, $display) -ForegroundColor Cyan
-            } else {
-                Write-Host ("{0,5}: {1}" -f $ln, $display)
-            }
+
+    # Read only as many lines as we need for context, instead of the entire file
+    $contextLines = Get-Content -Path $ScriptPath -TotalCount $end2
+    $lastLineToShow = [Math]::Min($end2, $contextLines.Count)
+
+    for ($ln = $start2; $ln -le $lastLineToShow; $ln++) {
+        $line = $contextLines[$ln - 1]
+        $display = ($line -replace "`t", "    ").TrimEnd()
+        if ($ln -eq $ns) {
+            Write-Host ("{0,5}: {1}" -f $ln, $display) -ForegroundColor Cyan
+        } else {
+            Write-Host ("{0,5}: {1}" -f $ln, $display)
         }
-        $ln++
     }
 
     Write-Host ""

--- a/Private/Show-MoreDetails.ps1
+++ b/Private/Show-MoreDetails.ps1
@@ -1,0 +1,128 @@
+function Show-MoreDetails {
+    <#
+    .SYNOPSIS
+        Displays detailed state and script context for an incomplete run.
+
+    .PARAMETER ExistingState
+        The object returned by Read-StepperState.
+
+    .PARAMETER ScriptPath
+        Path to the current script.
+
+    .PARAMETER CurrentHash
+        The current script hash.
+
+    .PARAMETER LastStep
+        Identifier of the last completed step (format: "path:line").
+
+    .PARAMETER NextStepLine
+        Line number where the next step will execute.
+
+    .PARAMETER ShowHashComparison
+        If set, prints both previous and current script hashes (used when script differs).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [pscustomobject]$ExistingState,
+        [Parameter(Mandatory)] [string]$ScriptPath,
+        [Parameter(Mandatory)] [string]$CurrentHash,
+        [Parameter(Mandatory)] [string]$LastStep,
+        [Parameter(Mandatory)] [int]$NextStepLine,
+        [switch]$ShowHashComparison
+    )
+
+    Write-Host ""
+    Write-Host "More details:" -ForegroundColor Yellow
+    Write-Host ""
+    if ($ShowHashComparison) {
+        Write-Host "  Previous script hash: $($ExistingState.ScriptHash)"
+        Write-Host "  Current script hash:  $CurrentHash"
+    }
+    Write-Host "  Script hash: $($ExistingState.ScriptHash)"
+
+    # Show Stepper variables and their contents
+    Write-Host ""
+    Write-Host "Stepper variables:"
+    Write-Host ""
+    if ($ExistingState.StepperData -and $ExistingState.StepperData.Count -gt 0) {
+        foreach ($var in ($ExistingState.StepperData.Keys | Sort-Object)) {
+            $val = $ExistingState.StepperData[$var]
+            try {
+                $valStr = $val | ConvertTo-Json -Depth 4 -ErrorAction Stop
+            } catch {
+                $valStr = ($val | Out-String).TrimEnd()
+            }
+
+            if ($valStr -match "`n") {
+                Write-Host ("  {0}:" -f $var)
+                $valStr -split "`n" | ForEach-Object { Write-Host "        $_" }
+            } else {
+                Write-Host ("  {0}: {1}" -f $var, $valStr)
+            }
+        }
+    } else {
+        Write-Host "      None"
+    }
+
+    # Show full contents of the last completed New-Step using saved script contents if available
+    Write-Host ""
+    Write-Host "Last completed step:"
+    Write-Host ""
+    if ($ExistingState.ScriptContents) {
+        $prevLines = $ExistingState.ScriptContents -split "`n"
+        $prevStepLine = ($LastStep -split ':')[-1] -as [int]
+
+        # Attempt to extract the full New-Step block by matching braces
+        $block = @()
+        $depth = 0
+        $started = $false
+        for ($i = $prevStepLine - 1; $i -lt $prevLines.Count; $i++) {
+            $lineText = $prevLines[$i]
+            $openCount = ([regex]::Matches($lineText, '\{')).Count
+            $closeCount = ([regex]::Matches($lineText, '\}')).Count
+
+            if (-not $started -and $openCount -gt 0) {
+                $started = $true
+            }
+            if ($started) {
+                $block += $lineText
+                $depth += $openCount - $closeCount
+                if ($depth -le 0) { break }
+            }
+        }
+
+        if ($block.Count -gt 0) {
+            $block | ForEach-Object { Write-Host "  $_" }
+        } else {
+            Write-Host "  Unable to extract step body." -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "  No saved script contents available." -ForegroundColor Yellow
+    }
+
+    # Show context around the restart line in the current script (2 lines before / 3 lines after)
+    Write-Host ""
+    Write-Host "Context around next restart line:"
+    Write-Host ""
+    $ns = [int]$NextStepLine
+    $start2 = [Math]::Max(1, $ns - 2)
+    $end2 = $ns + 3
+    $ln = 1
+    foreach ($line in (Get-Content -Path $ScriptPath)) {
+        if ($ln -ge $start2 -and $ln -le $end2) {
+            $display = ($line -replace "`t", "    ").TrimEnd()
+            if ($ln -eq $ns) {
+                Write-Host ("{0,5}: {1}" -f $ln, $display) -ForegroundColor Cyan
+            } else {
+                Write-Host ("{0,5}: {1}" -f $ln, $display)
+            }
+        }
+        $ln++
+    }
+
+    Write-Host ""
+
+    # Prompt header for available actions
+    Write-Host "How would you like to proceed?"
+    Write-Host ""
+}

--- a/Private/Update-ScriptWithNonResumableActions.ps1
+++ b/Private/Update-ScriptWithNonResumableActions.ps1
@@ -34,7 +34,6 @@ function Update-ScriptWithNonResumableActions {
 
     $newScriptLines = @()
     $linesToMove = @()
-    $lastBlock = $NewStepBlocks[$NewStepBlocks.Count - 1]
 
     # Group lines to wrap by consecutive sequences
     $linesToWrap = @($Actions.Keys | Where-Object { $Actions[$_].Action -eq 'Wrap' } | Sort-Object)

--- a/Private/Write-StepperState.ps1
+++ b/Private/Write-StepperState.ps1
@@ -18,6 +18,9 @@ function Write-StepperState {
     .PARAMETER StepperData
         The $Stepper hashtable to persist.
 
+    .PARAMETER ScriptContents
+        The full contents of the script at the time of saving (string). Useful for inspection when the script changes.
+
     .OUTPUTS
         None
     #>
@@ -33,11 +36,15 @@ function Write-StepperState {
         [string]$LastCompletedStep,
 
         [Parameter()]
-        [hashtable]$StepperData
+        [hashtable]$StepperData,
+
+        [Parameter()]
+        [string]$ScriptContents
     )
 
     $state = [PSCustomObject]@{
         ScriptHash        = $ScriptHash
+        ScriptContents    = $ScriptContents
         LastCompletedStep = $LastCompletedStep
         Timestamp         = (Get-Date).ToString('o')
         StepperData       = $StepperData

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -256,7 +256,7 @@ function New-Step {
                         Write-Host "  [M] More details" -ForegroundColor White
                         Write-Host "  [Q] Quit" -ForegroundColor White
                         Write-Host ""
-Write-Host "Choice? [r/S/m/q]: " -NoNewline
+                        Write-Host "Choice? [r/S/m/q]: " -NoNewline
                         $moreResponse = Read-Host
 
                         if ($moreResponse -eq '' -or $moreResponse -eq 'S' -or $moreResponse -eq 's') {

--- a/Stepper.psd1
+++ b/Stepper.psd1
@@ -8,7 +8,7 @@
     Description='A PowerShell module for creating resumable, step-by-step automation scripts with automatic state persistence and cross-platform support.'
     FunctionsToExport=@('New-Step',        'Stop-Stepper')
     GUID='2260142f-ef07-4749-a430-a2062efefbf6'
-    ModuleVersion='2025.12.20.1145'
+    ModuleVersion='2025.12.21.700'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{


### PR DESCRIPTION
**Summary:** Move resume state to per-run, persist `ScriptContents`, add **More details** view, and improve non‑resumable detection (`# stepper:ignore`).

**Key changes**
- Remove script‑scoped session state; use per‑run `__StepperExecutionState`
- Persist full script text in `.stepper` files (`ScriptContents`)
- Add `Private/Show-MoreDetails.ps1` to inspect saved state (step body + context)
- Better non‑resumable detection: multi‑line comments + `# stepper:ignore`
- Standardize prompts/menus and preserve leading whitespace in context output

**Main files**
- `Public/New-Step.ps1`
- `Private/Show-MoreDetails.ps1`
- `Private/Write-StepperState.ps1`