### PR TITLE
Fix Last Step Block Extraction Logic

### DIFF
--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -1,0 +1,48 @@
+### Git Workflow
+
+- Commit messages should be clear and descriptive
+- Use conventional commits format: `type(scope): message`
+  - Types: feat, fix, docs, style, refactor, test, chore
+  - Example: `feat(detection): add ESC13 detection`
+  - Example: `refactor(error-handling): use $PSCmdlet.WriteError in Get-AdcsObjects`
+  - Example: `fix(validation): add null check for module version in Test-IsLatestVersion`
+- **Never use vague messages** like "update XXXXX for internal improvements"
+  - ❌ Bad: `refactor: update functions for improvements`
+  - ❌ Bad: `chore: update error handling`
+  - ✅ Good: `refactor(error-handling): replace Write-Error with $PSCmdlet.WriteError in 8 functions`
+  - ✅ Good: `fix(pipeline): add ValueFromPipeline support to Test-IsModuleAvailable`
+
+#### Required Commit Message Detail Level
+
+**All commits must include detailed bullet points** explaining:
+1. What files were modified/created
+2. What functionality was added/changed
+3. What the code detects/does
+4. Additional context about the implementation
+
+**Example of required detail level:**
+```
+feat(detection): add ESC11 detection for CA RPC encryption requirement
+
+- Add ESC11 definition to ESCDefinitions.psd1
+- Integrate ESC11 scan into Invoke-Locksmith2.ps1
+- Detects CAs with IF_ENFORCEENCRYPTICERTREQUEST flag disabled
+- Identifies NTLM relay attack vulnerability
+- Provides fix/revert scripts using certutil
+```
+
+**Another example:**
+```
+feat(detection): add ESC6 detection for CA EDITF_ATTRIBUTESUBJECTALTNAME2 flag
+
+- Create Find-VulnerableCA.ps1 for CA-level vulnerability detection
+- Add ESC6 definition to ESCDefinitions.psd1
+- Integrate ESC6 scan into Invoke-Locksmith2.ps1
+- Detects CAs with EDITF_ATTRIBUTESUBJECTALTNAME2 enabled
+- Provides fix/revert scripts using certutil
+```
+
+- Keep commits atomic and focused
+- Update CHANGELOG.MD for user-facing changes
+- Be specific about what changed and why
+

--- a/Private/Show-MoreDetails.ps1
+++ b/Private/Show-MoreDetails.ps1
@@ -69,7 +69,12 @@ function Show-MoreDetails {
     Write-Host ""
     if ($ExistingState.ScriptContents) {
         $prevLines = $ExistingState.ScriptContents -split "`n"
-        $prevStepLine = ($LastStep -split ':')[-1] -as [int]
+        $prevStepLine = $null
+        if ($LastStep -and ($LastStep -match ':(\d+)$')) {
+            $prevStepLine = [int]$Matches[1]
+        } else {
+            Write-Host "  No valid LastCompletedStep recorded." -ForegroundColor Yellow
+        }
 
         # Attempt to extract the full New-Step block using PowerShell's AST,
         # so that braces inside strings or comments don't confuse the logic.
@@ -95,17 +100,88 @@ function Show-MoreDetails {
                 $true
             )
 
+            # Collect all New-Step commands with scriptblock arguments
+            $cmdList = $scriptAst.FindAll({ param($node) $node -is [System.Management.Automation.Language.CommandAst] -and ($node.GetCommandName() -eq 'New-Step') }, $true) |
+                      ForEach-Object {
+                          $sb = $_.CommandElements | Where-Object { $_ -is [System.Management.Automation.Language.ScriptBlockAst] } | Select-Object -First 1
+                          if ($sb) {
+                              [pscustomobject]@{
+                                  Command = $_
+                                  ScriptBlock = $sb
+                                  Start = $sb.Extent.StartLineNumber
+                                  End = $sb.Extent.EndLineNumber
+                                  CmdStart = $_.Extent.StartLineNumber
+                                  CmdEnd = $_.Extent.EndLineNumber
+                              }
+                          }
+                      }
+
             $scriptBlockAst = $null
-            if ($null -ne $cmdAst) {
-                $scriptBlockAst = $cmdAst.CommandElements | Where-Object { $_ -is [System.Management.Automation.Language.ScriptBlockAst] } | Select-Object -First 1
+
+            # Prefer a scriptblock that actually spans the previous step line
+            $candidate = $cmdList | Where-Object { $_.Start -le $prevStepLine -and $_.End -ge $prevStepLine } | Select-Object -First 1
+
+            # If none span the line, prefer a command whose declaration line matches the step line
+            if (-not $candidate) {
+                $candidate = $cmdList | Where-Object { $_.CmdStart -eq $prevStepLine } | Select-Object -First 1
             }
 
-            if ($null -ne $scriptBlockAst) {
-                $startLine = $scriptBlockAst.Extent.StartLineNumber
-                $endLine   = $scriptBlockAst.Extent.EndLineNumber
+            # If still none, pick the closest preceding scriptblock (highest Start <= prevStepLine)
+            if (-not $candidate) {
+                $candidate = $cmdList | Where-Object { $_.Start -lt $prevStepLine } | Sort-Object -Property Start -Descending | Select-Object -First 1
+            }
+
+            if ($candidate) {
+                $scriptBlockAst = $candidate.ScriptBlock
+                $startLine = $candidate.Start
+                $endLine = $candidate.End
 
                 for ($i = $startLine; $i -le $endLine -and $i -le $prevLines.Count; $i++) {
                     $block += $prevLines[$i - 1]
+                }
+            } else {
+                Write-Verbose "Show-MoreDetails: AST lookup failed for New-Step around line $prevStepLine; attempting manual brace-match fallback"
+
+                # Search upward for the nearest 'New-Step {' start line
+                $foundStart = $null
+                for ($s = $prevStepLine; $s -ge 1; $s--) {
+                    if ($prevLines[$s - 1] -match '^\s*New-Step\s*\{') {
+                        $foundStart = $s
+                        break
+                    }
+                }
+
+                if ($foundStart) {
+                    $level = 0
+                    $endLine = $foundStart
+
+                    for ($i = $foundStart; $i -le $prevLines.Count; $i++) {
+                        $lineText = $prevLines[$i - 1]
+
+                        # Strip simple quoted strings to reduce brace noise
+                        $stripped = $lineText -replace "'[^']*'", '' -replace '"[^"]*"', ''
+
+                        $opens = ($stripped -split '{').Count - 1
+                        $closes = ($stripped -split '}').Count - 1
+                        $level += $opens - $closes
+
+                        if ($level -le 0) {
+                            $endLine = $i
+                            break
+                        }
+                    }
+
+                    if ($endLine -ge $foundStart) {
+                        for ($i = $foundStart; $i -le $endLine -and $i -le $prevLines.Count; $i++) {
+                            $block += $prevLines[$i - 1]
+                        }
+                    }
+                    else {
+                        Write-Verbose "Show-MoreDetails: Manual brace-match failed to find end for New-Step starting at $foundStart"
+                    }
+                }
+                else {
+                    Write-Verbose "Show-MoreDetails: No 'New-Step {' found above line $prevStepLine"
                 }
             }
         }


### PR DESCRIPTION
- Added AST-based selection of the New-Step command and script-block argument; prefer candidates spanning the previous step line
- Added manual brace-match fallback to extract step body when AST selection fails (strips simple quoted strings when counting braces to reduce noise)
- Added validation for LastCompletedStep and verbose diagnostics to aid debugging
- Fixes: 'Last completed step' showing full script or 'Unable to extract step body' when AST lookup failed; now reliably extracts the New-Step body for More details view"
- Added 'Required Commit Message Detail Level' section in copilot-instrutions.md specifying required bullet points: files modified/created; functionality added/changed; what the code detects/does; additional implementation context