### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A PowerShell module for creating resumable scripts with automatic state persiste
 
 - Each step is tracked by its location in the script (file:line)
 - State is saved after each successful step in a `.stepper` file (includes `ScriptContents`, `LastCompletedStep`, timestamp, and persisted `$Stepper` data)
-- On resume, completed steps are skipped automatically
+- On resume, completed steps can be skipped automatically
 - If the script has changed between runs, Stepper prompts the user to Resume, Start over (removes the state file), view More details, or Quit
 - Non-resumable code is detected and can be suppressed with `# stepper:ignore` or handled interactively
 - Use the More details view to inspect saved step body, Stepper variables, and restart context

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A PowerShell module for creating resumable scripts with automatic state persistence.
 
+## How It Works
+
+- Each step is tracked by its location in the script (file:line)
+- State is saved after each successful step in a `.stepper` file (includes `ScriptContents`, `LastCompletedStep`, timestamp, and persisted `$Stepper` data)
+- On resume, completed steps are skipped automatically
+- If the script has changed between runs, Stepper prompts the user to Resume, Start over (removes the state file), view More details, or Quit
+- Non-resumable code is detected and can be suppressed with `# stepper:ignore` or handled interactively
+- Use the More details view to inspect saved step body, Stepper variables, and restart context
+- Call `Stop-Stepper` at the end to clean up
+
 ## Installation
 
 ```powershell
@@ -10,10 +20,12 @@ Install-Module -Name Stepper
 
 ## Usage
 
-Wrap your script steps in `New-Step` blocks. If the script fails, the next run resumes from the last completed step.
+Wrap your script steps in `New-Step` blocks. If the script fails inside of a `New-Step` block, the next run of the script resumes at the step that failed.
 
 ```powershell
 #Requires -Modules Stepper
+[CmdletBinding()]
+param()
 
 New-Step {
     Write-Host "Step 1: Download files..."
@@ -32,15 +44,6 @@ New-Step {
 
 Stop-Stepper
 ```
-
-## How It Works
-
-- Each step is tracked by its location in the script (file:line)
-- State is saved after each successful step in a `.stepper` file
-- On resume, completed steps are skipped automatically
-- Script changes invalidate the state file
-- Call `Stop-Stepper` at the end to clean up
-
 ## Data Persistence
 
 Use the `$Stepper` variable to share data between steps:


### PR DESCRIPTION
- Modified: README.md
- Clarify that completed steps are skipped automatically on resume
- Add bullet describing the 'More details' view (saved step body, Stepper variables, restart context)
- Note that .stepper state includes ScriptContents and persisted $Stepper data
- Purpose: improve docs accuracy and reduce confusion when resuming modified scripts