### PR TITLE
add: check if file has been saved before execution

### DIFF
--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -53,10 +53,17 @@ function New-Step {
     $lastColonIndex = $stepId.LastIndexOf(':')
     $scriptPath = $stepId.Substring(0, $lastColonIndex)
     
-    # Check if this is an unsaved file (URI scheme like untitled:)
-    if ($scriptPath -match '^[a-z][a-z0-9+.-]*:' -and $scriptPath -notmatch '^[a-z]:\\') {
+    #Region Check if this is an unsaved file
+    try {
+        $fullPath = [System.IO.Path]::GetFullPath($scriptPath)
+        if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+            throw "Stepper cannot be used with unsaved files. Please save the script first."
+        }
+    }
+    catch {
         throw "Stepper cannot be used with unsaved files. Please save the script first."
     }
+    #EndRegion Check if this is an unsaved file
     
     $currentHash = Get-ScriptHash -ScriptPath $scriptPath
     $statePath = Get-StepperStatePath -ScriptPath $scriptPath

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -52,6 +52,12 @@ function New-Step {
     # Extract script path from identifier (format: "path:line")
     $lastColonIndex = $stepId.LastIndexOf(':')
     $scriptPath = $stepId.Substring(0, $lastColonIndex)
+    
+    # Check if this is an unsaved file (URI scheme like untitled:)
+    if ($scriptPath -match '^[a-z][a-z0-9+.-]*:' -and $scriptPath -notmatch '^[a-z]:\\') {
+        throw "Stepper cannot be used with unsaved files. Please save the script first."
+    }
+    
     $currentHash = Get-ScriptHash -ScriptPath $scriptPath
     $statePath = Get-StepperStatePath -ScriptPath $scriptPath
 

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -48,7 +48,12 @@ function New-Step {
     }
 
     # Get step identifier and script info
-    $stepId = Get-StepIdentifier
+    try {
+        $stepId = Get-StepIdentifier
+    }
+    catch {
+        throw "Stepper cannot determine the step identifier. Ensure New-Step is called from a script file and not from the console or an unsaved file."
+    }
     # Extract script path from identifier (format: "path:line")
     $lastColonIndex = $stepId.LastIndexOf(':')
     $scriptPath = $stepId.Substring(0, $lastColonIndex)


### PR DESCRIPTION
Hi Jake,

I thought i would take a look at your new module i tried straight away the example and ofcourse i did not save the file i was testing in and ran into an error as shown below

## Code Example:
```powershell
. $args[0] #Requires -Modules Stepper
[CmdletBinding()]
param()

New-Step {
    Write-Host "Step 1: Download files..."
    # Your code here
}

New-Step {
    Write-Host "Step 2: Process data..."
    # Your code here
}

New-Step {
    Write-Host "Step 3: Upload results..."
    # Your code here
}

Stop-Stepper
```

## Error:

```powershell
Exception: C:\Users\Morte\Desktop\github\Stepper\Private\Get-ScriptHash.ps1:39:9
Line |
  39 |          throw "Failed to calculate hash for script '$ScriptPath': $_"
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Failed to calculate hash for script 'untitled:Untitled-1': Cannot find drive. A drive with the name 'untitled' does not exist.
```

This PR all that it does is get the full path of the file being run and tests that the file exists (might be a bit redundant but why not make sure :D) and throws an error if for some reason someone like me tries to run the sample from an unsaved file.

This now results in the following exception instead:
```powershell
Exception: C:\Users\Morte\Desktop\github\Stepper\Public\New-Step.ps1:64:9
Line |
  64 |          throw "Stepper cannot be used with unsaved files. Please save …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Stepper cannot be used with unsaved files. Please save the script first.
```

I did end up finding this article from Mike F. Robbins

https://mikefrobbins.com/2019/08/06/where-are-untitled-tabs-in-vscode-saved-on-a-windows-system/

But i personally felt like implementing this just so people who do not save their files would be to cumbersome