### PR TITLE
fix(parsing): make New-Step and Stop-Stepper pattern matching case-insensitive

### DIFF
--- a/Private/Find-NewStepBlocks.ps1
+++ b/Private/Find-NewStepBlocks.ps1
@@ -20,7 +20,7 @@ function Find-NewStepBlocks {
     $stopStepperLine = -1
 
     for ($i = 0; $i -lt $ScriptLines.Count; $i++) {
-        if ($ScriptLines[$i] -match '^\s*New-Step\s+\{') {
+        if ($ScriptLines[$i] -match '(?i)^\s*New-Step\s+\{') {
             # Find the closing brace for this New-Step block
             $braceCount = 0
             $blockStart = $i
@@ -44,7 +44,7 @@ function Find-NewStepBlocks {
                 }
             }
         }
-        if ($ScriptLines[$i] -match '^\s*Stop-Stepper') {
+        if ($ScriptLines[$i] -match '(?i)^\s*Stop-Stepper') {
             $stopStepperLine = $i
             break
         }

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -244,7 +244,7 @@ function New-Step {
             if ($existingState.ScriptHash -ne $currentHash) {
                 # Script has been modified since last run — prompt user for action
                 $scriptContent = Get-Content -Path $scriptPath -Raw
-                $stepMatches = [regex]::Matches($scriptContent, '^\s*New-Step\s+\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
+                $stepMatches = [regex]::Matches($scriptContent, '(?i)^\s*New-Step\s+\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
                 $totalSteps = $stepMatches.Count
 
                 # Find all step line numbers
@@ -252,7 +252,7 @@ function New-Step {
                 $lineNumber = 1
                 $lines = $scriptContent -split "`r?`n"
                 foreach ($line in $lines) {
-                    if ($line -match '^\s*New-Step\s+\{') {
+                    if ($line -match '(?i)^\s*New-Step\s+\{') {
                         $stepLines += "${scriptPath}:${lineNumber}"
                     }
                     $lineNumber++
@@ -364,14 +364,14 @@ function New-Step {
             else {
                 # Count total steps in the script by finding all New-Step calls
                 $scriptContent = Get-Content -Path $scriptPath -Raw
-                $stepMatches = [regex]::Matches($scriptContent, '^\s*New-Step\s+\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
+                $stepMatches = [regex]::Matches($scriptContent, '(?i)^\s*New-Step\s+\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
                 $totalSteps = $stepMatches.Count
 
                 # Find all step line numbers to determine which step number we're on
                 $stepLines = @()
                 $lineNumber = 1
                 foreach ($line in (Get-Content -Path $scriptPath)) {
-                    if ($line -match '^\s*New-Step\s+\{') {
+                    if ($line -match '(?i)^\s*New-Step\s+\{') {
                         $stepLines += "${scriptPath}:${lineNumber}"
                     }
                     $lineNumber++
@@ -531,14 +531,14 @@ function New-Step {
 
         # Calculate step number (X/Y)
         $scriptContent = Get-Content -Path $scriptPath -Raw
-        $stepMatches = [regex]::Matches($scriptContent, '^\s*New-Step\s+\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
+        $stepMatches = [regex]::Matches($scriptContent, '(?i)^\s*New-Step\s+\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
         $totalSteps = $stepMatches.Count
 
         # Find all step line numbers
         $stepLines = @()
         $lineNumber = 1
         foreach ($line in (Get-Content -Path $scriptPath)) {
-            if ($line -match '^\s*New-Step\s+\{') {
+            if ($line -match '(?i)^\s*New-Step\s+\{') {
                 $stepLines += "${scriptPath}:${lineNumber}"
             }
             $lineNumber++


### PR DESCRIPTION
- Modify New-Step.ps1 to add (?i) inline modifier to 6 regex patterns
- Modify Find-NewStepBlocks.ps1 to add (?i) inline modifier to 2 regex patterns
- Ensures Stepper recognizes commands regardless of casing (new-step, NEW-STEP, etc.)
- Supports inexperienced scripters who may not follow PascalCase conventions
- Aligns with PowerShell's case-insensitive function call behavior