### PR TITLE
fix(error-handling): enhance exception message for step failures in New-Step function

### DIFF
--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -750,7 +750,12 @@ function New-Step {
             }
         }
         catch {
-            $exception = [System.Exception]::new("Step failed at $stepId", $_.Exception)
+            $innerMessage = if ($_.Exception.Message) {
+                $_.Exception.Message
+            } else {
+                $_.ToString()
+            }
+            $exception = [System.Exception]::new("Step failed at ${stepId}: $innerMessage", $_.Exception)
             $errorRecord = [System.Management.Automation.ErrorRecord]::new(
                 $exception,
                 'StepExecutionFailed',

--- a/Stepper.psd1
+++ b/Stepper.psd1
@@ -8,7 +8,7 @@
     Description='A PowerShell module for creating resumable, step-by-step automation scripts with automatic state persistence and cross-platform support.'
     FunctionsToExport=@('New-Step',        'Stop-Stepper')
     GUID='2260142f-ef07-4749-a430-a2062efefbf6'
-    ModuleVersion='2026.1.6.2040'
+    ModuleVersion='2026.2.27.809'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{


### PR DESCRIPTION
Previously, when a step failed due to a terminating error, Stepper displayed only "Step failed at <path:line>" with no indication of what actually went wrong. The inner exception message was buried and required inspecting $_.Exception.InnerException to find.

Now the actual error message is included directly in the Stepper error output.

Before:

```
Step failed at C:\Scripts\MyScript.ps1:442
```

After:

```
Step failed at C:\Scripts\MyScript.ps1:442: Could not find file 'C:\path\to\file.csv'.
```

Modified New-Step.ps1 catch block to extract $_.Exception.Message (with $_.ToString() fallback)