### PR TITLE
feat(steps): add optional Name parameter to New-Step

### DIFF
--- a/Examples/Test.ps1
+++ b/Examples/Test.ps1
@@ -1,28 +1,38 @@
-Write-Output 'This code is useless. Delete it!' | Out-Null
+#requires -Modules Stepper
+[CmdletBinding()]
+param()
 
-New-Step {
+
+New-Step 'Enter Your Name' {
     $Stepper.Name = Read-Host 'Enter your name'
+    Write-Verbose "Running '$($Stepper.StepName)' (step $($Stepper.StepNumber))"
 }
 
+#region Stepper ignore
 Write-Output 'This code should execute every time the script runs.' | Out-Null
 Write-Output 'Mark this block w/ a special comment so Stepper ignores it.' |
     Out-Null
 $Stepper.ProcessCount = (Get-Process).Count
 $Stepper.ItemCount = (Get-ChildItem).Count
 $Stepper.CollectionTime = Get-Date
+#endregion Stepper ignore
 
-New-Step {
+New-Step 'Display Results' {
     $response = Read-Host 'Do you want to simulate a crash? [Y/n]'
     if ($response -eq '' -or $response -eq 'Y' -or $response -eq 'y') {
         Write-Host ""
         Write-Host "Oh no! A crash..." -ForegroundColor Red
         exit
     }
-    Write-Host "Hey, $($Stepper.Name)!"
+    Write-Host "Hey, $($Stepper.Name)! (running '$($Stepper.StepName)')"
     Write-Host "There are $($Stepper.ProcessCount) processes currently running."
 }
 
-Write-Output "Make this code resumable. Wrap it in New-Step {}." | Out-Null
-Write-Host "There are $($Stepper.ItemCount) items in this directory."
+New-Step {
+    Write-Output "Make this code resumable. Wrap it in New-Step {}." | Out-Null
+    Write-Host "There are $($Stepper.ItemCount) items in this directory."
+}
 
 #
+
+Stop-Stepper

--- a/Private/Find-NewStepBlocks.ps1
+++ b/Private/Find-NewStepBlocks.ps1
@@ -20,7 +20,7 @@ function Find-NewStepBlocks {
     $stopStepperLine = -1
 
     for ($i = 0; $i -lt $ScriptLines.Count; $i++) {
-        if ($ScriptLines[$i] -match '(?i)^\s*New-Step\s+\{') {
+        if ($ScriptLines[$i] -match '(?i)^\s*New-Step\s+(?:(?:-Name\s+)?(?:"[^"]*"|''[^'']*'')\s+)?\{') {
             # Find the closing brace for this New-Step block
             $braceCount = 0
             $blockStart = $i

--- a/Private/Show-MoreDetails.ps1
+++ b/Private/Show-MoreDetails.ps1
@@ -28,6 +28,8 @@ function Show-MoreDetails {
         [Parameter(Mandatory)] [string]$CurrentHash,
         [Parameter(Mandatory)] [string]$LastStep,
         [Parameter(Mandatory)] [int]$NextStepLine,
+        [Parameter()] [string]$NextStepName,
+        [Parameter()] [int]$NextStepNumber,
         [switch]$ShowHashComparison
     )
 
@@ -65,7 +67,16 @@ function Show-MoreDetails {
 
     # Show full contents of the last completed New-Step using saved script contents if available
     Write-Host ""
-    Write-Host "Last completed step:"
+    $lastStepLine = if ($LastStep -match ':(\d+)$') { $Matches[1] } else { '?' }
+    $lastStepNumber = $ExistingState.LastCompletedStepNumber
+    $lastStepLabel = if ($ExistingState.LastCompletedStepName) {
+        "$($ExistingState.LastCompletedStepName) (Step $lastStepNumber, Line $lastStepLine)"
+    } elseif ($lastStepNumber) {
+        "Step $lastStepNumber (Line $lastStepLine)"
+    } else {
+        "Line $lastStepLine"
+    }
+    Write-Host "Last completed step: $lastStepLabel"
     Write-Host ""
     if ($ExistingState.ScriptContents) {
         $prevLines = $ExistingState.ScriptContents -split "`n"
@@ -159,7 +170,7 @@ function Show-MoreDetails {
                 # Search upward for the nearest 'New-Step {' start line
                 $foundStart = $null
                 for ($s = $prevStepLine; $s -ge 1; $s--) {
-                    if ($prevLines[$s - 1] -match '^\s*New-Step\s*\{') {
+                    if ($prevLines[$s - 1] -match '(?i)^\s*New-Step\s+(?:(?:-Name\s+)?(?:"[^"]*"|''[^'']*'')\s+)?\{') {
                         $foundStart = $s
                         break
                     }
@@ -211,7 +222,14 @@ function Show-MoreDetails {
 
     # Show context around the restart line in the current script (2 lines before / 3 lines after)
     Write-Host ""
-    Write-Host "Context around next restart line:"
+    $nextRestartHeader = if ($NextStepName) {
+        "$NextStepName (Step $NextStepNumber, Line $NextStepLine)"
+    } elseif ($NextStepNumber -gt 0) {
+        "Step $NextStepNumber (Line $NextStepLine)"
+    } else {
+        "Line $NextStepLine"
+    }
+    Write-Host "Context around next restart line: $nextRestartHeader"
     Write-Host ""
     $ns = [int]$NextStepLine
     $start2 = [Math]::Max(1, $ns - 2)

--- a/Private/Write-StepperState.ps1
+++ b/Private/Write-StepperState.ps1
@@ -15,6 +15,12 @@ function Write-StepperState {
     .PARAMETER LastCompletedStep
         Identifier of the last successfully completed step (format: "filepath:line").
 
+    .PARAMETER StepName
+        Optional name of the completed step.
+
+    .PARAMETER StepNumber
+        1-based index of the completed step.
+
     .PARAMETER StepperData
         The $Stepper hashtable to persist.
 
@@ -36,6 +42,12 @@ function Write-StepperState {
         [string]$LastCompletedStep,
 
         [Parameter()]
+        [string]$StepName,
+
+        [Parameter()]
+        [int]$StepNumber,
+
+        [Parameter()]
         [hashtable]$StepperData,
 
         [Parameter()]
@@ -43,11 +55,13 @@ function Write-StepperState {
     )
 
     $state = [PSCustomObject]@{
-        ScriptHash        = $ScriptHash
-        ScriptContents    = $ScriptContents
-        LastCompletedStep = $LastCompletedStep
-        Timestamp         = (Get-Date).ToString('o')
-        StepperData       = $StepperData
+        ScriptHash              = $ScriptHash
+        ScriptContents          = $ScriptContents
+        LastCompletedStep       = $LastCompletedStep
+        LastCompletedStepName   = $StepName
+        LastCompletedStepNumber = $StepNumber
+        Timestamp               = (Get-Date).ToString('o')
+        StepperData             = $StepperData
     }
 
     try {

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -11,29 +11,42 @@ function New-Step {
         The script content is hashed to detect modifications. If the script changes
         between runs, the state is invalidated and execution starts fresh.
 
+    .PARAMETER Name
+        Optional name for this step. Displayed in verbose output and resume prompts.
+
     .PARAMETER ScriptBlock
         The code to execute for this step.
 
     .EXAMPLE
-        New-Step {
+        New-Step 'Download Files' {
             Write-Host "Downloading files..."
             Start-Sleep -Seconds 2
         }
 
-        New-Step {
+        New-Step 'Process Data' {
             Write-Host "Processing data..."
             Start-Sleep -Seconds 2
         }
 
         If the script fails during processing, the next run will skip the download step.
+        $Stepper.StepName and $Stepper.StepNumber are available inside each block.
+
+    .EXAMPLE
+        New-Step {
+            Write-Host "Unnamed step — backward-compatible syntax."
+        }
 
     .NOTES
         State files are stored alongside the script with a .stepper extension.
         Call Stop-Stepper at the end of your script to remove the state file upon successful completion.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Unnamed')]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(ParameterSetName = 'Named', Mandatory, Position = 0)]
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'Named', Mandatory, Position = 1)]
+        [Parameter(ParameterSetName = 'Unnamed', Mandatory, Position = 0)]
         [scriptblock]$ScriptBlock
     )
 
@@ -333,16 +346,22 @@ function New-Step {
                     )
                     $PSCmdlet.ThrowTerminatingError($errorRecord)
                 }
-                $stepMatches = [regex]::Matches($scriptContent, '(?i)^\s*New-Step\s+\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
+                $stepMatches = [regex]::Matches($scriptContent, '(?i)^\s*New-Step\s+(?:(?:-Name\s+)?(?:"[^"]*"|''[^'']*'')\s+)?\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
                 $totalSteps = $stepMatches.Count
 
-                # Find all step line numbers
+                # Find all step line numbers and names
                 $stepLines = @()
+                $stepNames = @()
                 $lineNumber = 1
                 $lines = $scriptContent -split "`r?`n"
                 foreach ($line in $lines) {
-                    if ($line -match '(?i)^\s*New-Step\s+\{') {
+                    if ($line -match '(?i)^\s*New-Step\s+(?:(?:-Name\s+)?(?:"[^"]*"|''[^'']*'')\s+)?\{') {
                         $stepLines += "${scriptPath}:${lineNumber}"
+                        if ($line -match '(?i)^\s*New-Step\s+(?:-Name\s+)?(?:"([^"]*)"|''([^'']*)'')') {
+                            $stepNames += if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+                        } else {
+                            $stepNames += $null
+                        }
                     }
                     $lineNumber++
                 }
@@ -361,20 +380,25 @@ function New-Step {
                 $scriptName = Split-Path $scriptPath -Leaf
                 $nextStepId = $stepLines[$lastStepIndex + 1]
                 $nextStepLine = ($nextStepId -split ':')[-1]
+                $nextStepName = $stepNames[$lastStepIndex + 1]
+                $nextStepDisplay = if ($nextStepName) { "$nextStepName (Step $nextStepNumber, Line $nextStepLine)" } else { "Step $nextStepNumber (Line $nextStepLine)" }
+                $lastStepLine = ($lastStep -split ':')[-1]
+                $lastStepDisplay = if ($existingState.LastCompletedStepName) { "$($existingState.LastCompletedStepName) (Step $($lastStepIndex + 1), Line $lastStepLine)" } else { "Step $($lastStepIndex + 1) (Line $lastStepLine)" }
 
                 while ($true) {
                     Write-Host ""
                     Write-Host "[!] Incomplete script run detected, but $scriptName has been modified." -ForegroundColor Magenta
                     Write-Host ""
-                    Write-Host "Total Steps:      $totalSteps"
-                    Write-Host "Steps Completed:  $($lastStepIndex + 1)"
-                    Write-Host "Variables:        $availableVars"
-                    Write-Host "Last Activity:    $timestamp"
+                    Write-Host "Total Steps:           $totalSteps"
+                    Write-Host "Steps Completed:       $($lastStepIndex + 1)"
+                    Write-Host "Last Completed Step:   $lastStepDisplay"
+                    Write-Host "Variables:             $availableVars"
+                    Write-Host "Last Activity:         $timestamp"
                     Write-Host ""
 
                     Write-Host "How would you like to proceed?"
                     Write-Host ""
-                    Write-Host "  [R] Resume $scriptName from Line ${nextStepLine} (May produce inconsistent results)" -ForegroundColor White
+                    Write-Host "  [R] Resume $scriptName from $nextStepDisplay (May produce inconsistent results)" -ForegroundColor White
                     Write-Host "  [S] Start over (Default)" -ForegroundColor Cyan
                     Write-Host "  [M] More details" -ForegroundColor White
                     Write-Host "  [Q] Quit" -ForegroundColor White
@@ -399,21 +423,20 @@ function New-Step {
                     }
                     elseif ($response -eq 'R' -or $response -eq 'r') {
                         Write-Host ""
-                        Write-Host "Resuming from Step $nextStepNumber..." -ForegroundColor Green
+                        Write-Host "Resuming from $nextStepDisplay..." -ForegroundColor Green
                         $executionState.RestoreMode = $true
                         $executionState.TargetStep = $lastStep
                         break
                     }
                     elseif ($response -eq 'M' -or $response -eq 'm') {
-                        Show-MoreDetails -ExistingState $existingState -ScriptPath $scriptPath -CurrentHash $currentHash -LastStep $lastStep -NextStepLine $nextStepLine -ShowHashComparison
+                        Show-MoreDetails -ExistingState $existingState -ScriptPath $scriptPath -CurrentHash $currentHash -LastStep $lastStep -NextStepLine $nextStepLine -NextStepName $nextStepName -NextStepNumber $nextStepNumber -ShowHashComparison
 
                         # Re-display the bottom inline menu and accept an immediate choice
-                        Write-Host "  [R] Resume $scriptName from Line ${nextStepLine} (May produce inconsistent results)" -ForegroundColor White
+                        Write-Host "  [R] Resume $scriptName from $nextStepDisplay (May produce inconsistent results)" -ForegroundColor White
                         Write-Host "  [S] Start over (Default)" -ForegroundColor Cyan
-                        Write-Host "  [M] More details" -ForegroundColor White
                         Write-Host "  [Q] Quit" -ForegroundColor White
                         Write-Host ""
-                        Write-Host "Choice? [r/S/m/q]: " -NoNewline
+                        Write-Host "Choice? [r/S/q]: " -NoNewline
                         try {
                             $moreResponse = Read-Host
                         }
@@ -430,14 +453,10 @@ function New-Step {
                         }
                         elseif ($moreResponse -eq 'R' -or $moreResponse -eq 'r') {
                             Write-Host ""
-                            Write-Host "Resuming from Step $nextStepNumber..." -ForegroundColor Green
+                            Write-Host "Resuming from $nextStepDisplay..." -ForegroundColor Green
                             $executionState.RestoreMode = $true
                             $executionState.TargetStep = $lastStep
                             break
-                        }
-                        elseif ($moreResponse -eq 'M' -or $moreResponse -eq 'm') {
-                            # Re-display details (loop)
-                            continue
                         }
                         elseif ($moreResponse -eq 'Q' -or $moreResponse -eq 'q') {
                             Write-Host ""
@@ -479,16 +498,22 @@ function New-Step {
                     )
                     $PSCmdlet.ThrowTerminatingError($errorRecord)
                 }
-                $stepMatches = [regex]::Matches($scriptContent, '(?i)^\s*New-Step\s+\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
+                $stepMatches = [regex]::Matches($scriptContent, '(?i)^\s*New-Step\s+(?:(?:-Name\s+)?(?:"[^"]*"|''[^'']*'')\s+)?\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
                 $totalSteps = $stepMatches.Count
 
-                # Find all step line numbers to determine which step number we're on
+                # Find all step line numbers and names to determine which step number we're on
                 $stepLines = @()
+                $stepNames = @()
                 $lineNumber = 1
                 try {
                     foreach ($line in (Get-Content -Path $scriptPath -ErrorAction Stop)) {
-                        if ($line -match '(?i)^\s*New-Step\s+\{') {
+                        if ($line -match '(?i)^\s*New-Step\s+(?:(?:-Name\s+)?(?:"[^"]*"|''[^'']*'')\s+)?\{') {
                             $stepLines += "${scriptPath}:${lineNumber}"
+                            if ($line -match '(?i)^\s*New-Step\s+(?:-Name\s+)?(?:"([^"]*)"|''([^'']*)'')') {
+                                $stepNames += if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+                            } else {
+                                $stepNames += $null
+                            }
                         }
                         $lineNumber++
                     }
@@ -518,13 +543,17 @@ function New-Step {
                     'None'
                 }
 
+                $lastStepLine = ($lastStep -split ':')[-1]
+                $lastStepDisplay = if ($existingState.LastCompletedStepName) { "$($existingState.LastCompletedStepName) (Step $($lastStepIndex + 1), Line $lastStepLine)" } else { "Step $($lastStepIndex + 1) (Line $lastStepLine)" }
+
                 Write-Host ""
                 Write-Host "[!] Incomplete script run detected!" -ForegroundColor Magenta
                 Write-Host ""
-                Write-Host "Total Steps:      $totalSteps"
-                Write-Host "Steps Completed:  $($lastStepIndex + 1)"
-                Write-Host "Variables:        $availableVars"
-                Write-Host "Last Activity:    $timestamp"
+                Write-Host "Total Steps:           $totalSteps"
+                Write-Host "Steps Completed:       $($lastStepIndex + 1)"
+                Write-Host "Last Completed Step:   $lastStepDisplay"
+                Write-Host "Variables:             $availableVars"
+                Write-Host "Last Activity:         $timestamp"
                 Write-Host ""
 
                 if ($nextStepNumber -le $totalSteps) {
@@ -532,11 +561,13 @@ function New-Step {
                     $scriptName = Split-Path $scriptPath -Leaf
                     $nextStepId = $stepLines[$lastStepIndex + 1]
                     $nextStepLine = ($nextStepId -split ':')[-1]
+                    $nextStepName = $stepNames[$lastStepIndex + 1]
+                    $nextStepDisplay = if ($nextStepName) { "$nextStepName (Step $nextStepNumber, Line $nextStepLine)" } else { "Step $nextStepNumber (Line $nextStepLine)" }
 
                     while ($true) {
                         Write-Host "How would you like to proceed?"
                         Write-Host ""
-                        Write-Host "  [R] Resume $scriptName from Line ${nextStepLine} (Default)" -ForegroundColor Cyan
+                        Write-Host "  [R] Resume $scriptName from $nextStepDisplay (Default)" -ForegroundColor Cyan
                         Write-Host "  [S] Start over" -ForegroundColor White
                         Write-Host "  [M] More details" -ForegroundColor White
                         Write-Host "  [Q] Quit" -ForegroundColor White
@@ -555,7 +586,7 @@ function New-Step {
 
                         if ($response -eq '' -or $response -eq 'R' -or $response -eq 'r') {
                             Write-Host ""
-                            Write-Host "Resuming from Step $nextStepNumber..." -ForegroundColor Green
+                            Write-Host "Resuming from $nextStepDisplay..." -ForegroundColor Green
                             $executionState.RestoreMode = $true
                             $executionState.TargetStep = $lastStep
                             break
@@ -566,15 +597,14 @@ function New-Step {
                             break
                         }
                         elseif ($response -eq 'M' -or $response -eq 'm') {
-                            Show-MoreDetails -ExistingState $existingState -ScriptPath $scriptPath -CurrentHash $currentHash -LastStep $lastStep -NextStepLine $nextStepLine
+                            Show-MoreDetails -ExistingState $existingState -ScriptPath $scriptPath -CurrentHash $currentHash -LastStep $lastStep -NextStepLine $nextStepLine -NextStepName $nextStepName -NextStepNumber $nextStepNumber
 
                             # Print the action menu again at the bottom of the details and accept an immediate choice
-                            Write-Host "  [R] Resume $scriptName from Line ${nextStepLine} (Default)" -ForegroundColor Cyan
+                            Write-Host "  [R] Resume $scriptName from $nextStepDisplay (Default)" -ForegroundColor Cyan
                             Write-Host "  [S] Start over" -ForegroundColor White
-                            Write-Host "  [M] More details" -ForegroundColor White
                             Write-Host "  [Q] Quit" -ForegroundColor White
                             Write-Host ""
-                            Write-Host "Choice? [R/s/m/q]: " -NoNewline
+                            Write-Host "Choice? [R/s/q]: " -NoNewline
                             try {
                                 $moreResponse = Read-Host
                             }
@@ -591,14 +621,10 @@ function New-Step {
                             }
                             elseif ($moreResponse -eq 'R' -or $moreResponse -eq 'r') {
                                 Write-Host ""
-                                Write-Host "Resuming from Step $nextStepNumber..." -ForegroundColor Green
+                                Write-Host "Resuming from $nextStepDisplay..." -ForegroundColor Green
                                 $executionState.RestoreMode = $true
                                 $executionState.TargetStep = $lastStep
                                 break
-                            }
-                            elseif ($moreResponse -eq 'M' -or $moreResponse -eq 'm') {
-                                # Re-display details (loop)
-                                continue
                             }
                             elseif ($moreResponse -eq 'Q' -or $moreResponse -eq 'q') {
                                 Write-Host ""
@@ -620,7 +646,7 @@ function New-Step {
                         else {
                             # Default to Resume for invalid input
                             Write-Host ""
-                            Write-Host "Resuming from Step $nextStepNumber..." -ForegroundColor Green
+                            Write-Host "Resuming from $nextStepDisplay..." -ForegroundColor Green
                             $executionState.RestoreMode = $true
                             $executionState.TargetStep = $lastStep
                             break
@@ -684,16 +710,22 @@ function New-Step {
             )
             $PSCmdlet.ThrowTerminatingError($errorRecord)
         }
-        $stepMatches = [regex]::Matches($scriptContent, '(?i)^\s*New-Step\s+\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
+        $stepMatches = [regex]::Matches($scriptContent, '(?i)^\s*New-Step\s+(?:(?:-Name\s+)?(?:"[^"]*"|''[^'']*'')\s+)?\{', [System.Text.RegularExpressions.RegexOptions]::Multiline)
         $totalSteps = $stepMatches.Count
 
-        # Find all step line numbers
+        # Find all step line numbers and names
         $stepLines = @()
+        $stepNames = @()
         $lineNumber = 1
         try {
             foreach ($line in (Get-Content -Path $scriptPath -ErrorAction Stop)) {
-                if ($line -match '(?i)^\s*New-Step\s+\{') {
+                if ($line -match '(?i)^\s*New-Step\s+(?:(?:-Name\s+)?(?:"[^"]*"|''[^'']*'')\s+)?\{') {
                     $stepLines += "${scriptPath}:${lineNumber}"
+                    if ($line -match '(?i)^\s*New-Step\s+(?:-Name\s+)?(?:"([^"]*)"|''([^'']*)'')') {
+                        $stepNames += if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+                    } else {
+                        $stepNames += $null
+                    }
                 }
                 $lineNumber++
             }
@@ -710,7 +742,8 @@ function New-Step {
         }
         $currentStepNumber = $stepLines.IndexOf($stepId) + 1
 
-        Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Executing step $currentStepNumber/$totalSteps ($displayStepId)"
+        $stepDisplaySuffix = if ($PSCmdlet.ParameterSetName -eq 'Named') { " - '$Name'" } else { '' }
+        Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Executing step $currentStepNumber/$totalSteps$stepDisplaySuffix ($displayStepId)"
 
         # Show current $Stepper data
         try {
@@ -721,6 +754,17 @@ function New-Step {
             }
         } catch {
             # Ignore if unable to read $Stepper
+        }
+
+        # Inject step metadata into $Stepper
+        try {
+            $stepperData = $callingScope.PSVariable.Get('Stepper').Value
+            if ($stepperData -is [hashtable]) {
+                $stepperData['StepName'] = if ($PSCmdlet.ParameterSetName -eq 'Named') { $Name } else { $null }
+                $stepperData['StepNumber'] = $currentStepNumber
+            }
+        } catch {
+            # Ignore if unable to inject step metadata
         }
 
         try {
@@ -742,7 +786,8 @@ function New-Step {
                 )
                 $PSCmdlet.ThrowTerminatingError($errorRecord)
             }
-            Write-StepperState -StatePath $statePath -ScriptHash $currentHash -LastCompletedStep $stepId -StepperData $stepperData -ScriptContents $scriptContents
+            $completedStepName = if ($PSCmdlet.ParameterSetName -eq 'Named') { $Name } else { $null }
+            Write-StepperState -StatePath $statePath -ScriptHash $currentHash -LastCompletedStep $stepId -StepName $completedStepName -StepNumber $currentStepNumber -StepperData $stepperData -ScriptContents $scriptContents
             Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Step $currentStepNumber/$totalSteps completed ($displayStepId)"
 
             if ($stepperData -and $stepperData.Count -gt 0) {

--- a/Stepper.psd1
+++ b/Stepper.psd1
@@ -8,7 +8,7 @@
     Description='A PowerShell module for creating resumable, step-by-step automation scripts with automatic state persistence and cross-platform support.'
     FunctionsToExport=@('New-Step',        'Stop-Stepper')
     GUID='2260142f-ef07-4749-a430-a2062efefbf6'
-    ModuleVersion='2026.2.27.809'
+    ModuleVersion='2026.3.7.1307'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Stepper.psm1
+++ b/Stepper.psm1
@@ -5,7 +5,8 @@ if ($env:STEPPER_SHOW_LOGO -ne 'false') {
 
 # Get public and private function definition files.
 $Public = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue -Recurse )
-$Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue -Recurse )
+$Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue -Recurse |
+        Where-Object { $_.Name -ne 'Show-Logo.ps1' } )
 $Classes = @( Get-ChildItem -Path $PSScriptRoot\Classes\*.ps1 -ErrorAction SilentlyContinue -Recurse )
 $Enums = @( Get-ChildItem -Path $PSScriptRoot\Enums\*.ps1 -ErrorAction SilentlyContinue -Recurse )
 # Get all assemblies


### PR DESCRIPTION
- Add Named/Unnamed parameter sets; supports New-Step 'name' { } and New-Step -Name 'name' { }
- Inject $Stepper.StepName and $Stepper.StepNumber before each scriptblock executes
- Resume prompts show Name (Step X, Line Y) for named steps, Step X (Line Y) for unnamed
- Persist LastCompletedStepName/LastCompletedStepNumber to state; surface in incomplete-run and More Details displays
- Fix double logo on Import-Module by excluding Show-Logo.ps1 from bulk Private dot-source in Stepper.psm1