### PR TITLE
fix(error-handling): include actual error line number in step failure message

### DIFF
--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -800,7 +800,11 @@ function New-Step {
             } else {
                 $_.ToString()
             }
-            $exception = [System.Exception]::new("Step failed at ${stepId}: $innerMessage", $_.Exception)
+            $origin = $_.InvocationInfo
+            $location = if ($origin.ScriptName -and $origin.ScriptLineNumber) {
+                "$([System.IO.Path]::GetFileName($origin.ScriptName)):$($origin.ScriptLineNumber)"
+            } else { $stepId }
+            $exception = [System.Exception]::new("Step failed [$location]: $innerMessage", $_.Exception)
             $errorRecord = [System.Management.Automation.ErrorRecord]::new(
                 $exception,
                 'StepExecutionFailed',


### PR DESCRIPTION
- Replace generic "Step failed at stepId" message with "Step failed [file:line]"
- Capture $_.InvocationInfo before constructing new ErrorRecord
- Use GetFileName() to keep message concise (no full path)
- Retain 4-arg ErrorRecord constructor for proper cmdlet error record semantics
- Inner exception preserved for programmatic access via InnerException