### PR TITLE
test: add comprehensive Pester v5 test suite for state management and public API

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -13,13 +13,13 @@ if (Get-Module -Name 'PSPublishModule' -ListAvailable) {
     try {
         Install-Module -Name Pester -AllowClobber -Scope CurrentUser -SkipPublisherCheck -Force
         Install-Module -Name PSScriptAnalyzer -AllowClobber -Scope CurrentUser -Force
-        Install-Module -Name PSPublishModule -AllowClobber -Scope CurrentUser -Force
+        Install-Module -Name PSPublishModule -AllowClobber -MaximumVersion 2.0.27 -Scope CurrentUser -Force
     } catch {
         Write-Error "PSPublishModule installation failed. $_"
     }
 }
 
-Update-Module -Name PSPublishModule
+# Update-Module -Name PSPublishModule
 Import-Module -Name PSPublishModule -Force
 
 $CopyrightYear = if ($Calver) { $CalVer.Split('.')[0] } else { (Get-Date -Format yyyy) }

--- a/Stepper.psd1
+++ b/Stepper.psd1
@@ -8,7 +8,7 @@
     Description='A cross-platform PowerShell utility module for creating resumable, step-by-step scripts with automatic state persistence.'
     FunctionsToExport=@('New-Step',        'Stop-Stepper')
     GUID='2260142f-ef07-4749-a430-a2062efefbf6'
-    ModuleVersion='2026.3.8.945'
+    ModuleVersion='2026.3.17.1944'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Tests/Get-StepIdentifier.Tests.ps1
+++ b/Tests/Get-StepIdentifier.Tests.ps1
@@ -1,0 +1,185 @@
+BeforeAll {
+    $ModulePath = Split-Path -Path $PSScriptRoot -Parent
+    . "$ModulePath/Private/Get-StepIdentifier.ps1"
+}
+
+Describe 'Get-StepIdentifier' -Tag 'Unit' {
+    Context 'When called directly from a user script' {
+        It 'Returns a string in filepath:line format' {
+            $result = Get-StepIdentifier
+            $result | Should -Match '^.+:\d+$'
+        }
+
+        It 'Returns a positive line number' {
+            $result = Get-StepIdentifier
+            $linePart = [int]($result -split ':')[-1]
+            $linePart | Should -BeGreaterThan 0
+        }
+
+        It 'Returns a path to an existing file' {
+            $result = Get-StepIdentifier
+            $filePart = $result.Substring(0, $result.LastIndexOf(':'))
+            $filePart | Should -Exist
+        }
+    }
+
+    Context 'When call stack has only module frames' {
+        BeforeAll {
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $stepperDir = Split-Path -Path $PSScriptRoot -Parent
+            $script:ModuleOnlyFrames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${stepperDir}${sep}Private${sep}Get-StepIdentifier.ps1"
+                    ScriptLineNumber = 5
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = "${stepperDir}${sep}Public${sep}New-Step.ps1"
+                    ScriptLineNumber = 42
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $null
+                    ScriptLineNumber = 0
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack { $script:ModuleOnlyFrames }
+        }
+
+        It 'Throws a terminating error' {
+            { Get-StepIdentifier -ErrorAction Stop } | Should -Throw
+        }
+
+        It 'Throws with StepIdentifierNotDetermined error id' {
+            try {
+                Get-StepIdentifier -ErrorAction Stop
+            } catch {
+                $_.FullyQualifiedErrorId | Should -Match 'StepIdentifierNotDetermined'
+            }
+        }
+    }
+
+    Context 'When call stack includes Private/ frames before user script' {
+        BeforeAll {
+            $script:UserScript1 = Join-Path $TestDrive 'user-script.ps1'
+            Set-Content -Path $script:UserScript1 -Value 'New-Step { }'
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $stepperDir = Split-Path -Path $PSScriptRoot -Parent
+            $script:PrivateFrames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${stepperDir}${sep}Private${sep}Get-StepIdentifier.ps1"
+                    ScriptLineNumber = 5
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = "${stepperDir}${sep}Private${sep}Some-Helper.ps1"
+                    ScriptLineNumber = 10
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $script:UserScript1
+                    ScriptLineNumber = 3
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack { $script:PrivateFrames }
+        }
+
+        It 'Skips Private/ frames and returns user script identifier' {
+            $result = Get-StepIdentifier
+            $result | Should -Be "${script:UserScript1}:3"
+        }
+    }
+
+    Context 'When call stack includes Public/ frames before user script' {
+        BeforeAll {
+            $script:UserScript2 = Join-Path $TestDrive 'user-script2.ps1'
+            Set-Content -Path $script:UserScript2 -Value 'New-Step { }'
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $stepperDir = Split-Path -Path $PSScriptRoot -Parent
+            $script:PublicFrames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${stepperDir}${sep}Public${sep}New-Step.ps1"
+                    ScriptLineNumber = 100
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $script:UserScript2
+                    ScriptLineNumber = 7
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack { $script:PublicFrames }
+        }
+
+        It 'Skips Public/ frames and returns user script identifier' {
+            $result = Get-StepIdentifier
+            $result | Should -Be "${script:UserScript2}:7"
+        }
+    }
+
+    Context 'When call stack includes Stepper.psm1 frame before user script' {
+        BeforeAll {
+            $script:UserScript3 = Join-Path $TestDrive 'user-script3.ps1'
+            Set-Content -Path $script:UserScript3 -Value 'New-Step { }'
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $stepperDir = Split-Path -Path $PSScriptRoot -Parent
+            $script:Psm1Frames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${stepperDir}${sep}Stepper.psm1"
+                    ScriptLineNumber = 20
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $script:UserScript3
+                    ScriptLineNumber = 5
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack { $script:Psm1Frames }
+        }
+
+        It 'Skips Stepper.psm1 frame and returns user script identifier' {
+            $result = Get-StepIdentifier
+            $result | Should -Be "${script:UserScript3}:5"
+        }
+    }
+
+    Context 'When call stack has multiple module frames followed by user script' {
+        BeforeAll {
+            $script:UserScript4 = Join-Path $TestDrive 'user-script4.ps1'
+            Set-Content -Path $script:UserScript4 -Value 'New-Step { }'
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $stepperDir = Split-Path -Path $PSScriptRoot -Parent
+            $script:MixedFrames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${stepperDir}${sep}Private${sep}Get-StepIdentifier.ps1"
+                    ScriptLineNumber = 5
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = "${stepperDir}${sep}Public${sep}New-Step.ps1"
+                    ScriptLineNumber = 42
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = "${stepperDir}${sep}Stepper.psm1"
+                    ScriptLineNumber = 8
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $script:UserScript4
+                    ScriptLineNumber = 12
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack { $script:MixedFrames }
+        }
+
+        It 'Returns the first non-module user script frame' {
+            $result = Get-StepIdentifier
+            $result | Should -Be "${script:UserScript4}:12"
+        }
+    }
+}

--- a/Tests/New-Step.Tests.ps1
+++ b/Tests/New-Step.Tests.ps1
@@ -1,0 +1,404 @@
+BeforeAll {
+    $ModulePath = Split-Path -Path $PSScriptRoot -Parent
+    . "$ModulePath/Private/Get-StepIdentifier.ps1"
+    . "$ModulePath/Private/Get-ScriptHash.ps1"
+    . "$ModulePath/Private/Get-StepperStatePath.ps1"
+    . "$ModulePath/Private/Write-StepperState.ps1"
+    . "$ModulePath/Private/Read-StepperState.ps1"
+    . "$ModulePath/Private/Remove-StepperState.ps1"
+    . "$ModulePath/Private/Test-LineInIgnoredRegion.ps1"
+    . "$ModulePath/Private/Find-NewStepBlocks.ps1"
+    . "$ModulePath/Private/Find-UnmanagedCodeBlocks.ps1"
+    . "$ModulePath/Private/Get-UnmanagedCodeAction.ps1"
+    . "$ModulePath/Private/Update-ScriptWithUnmanagedActions.ps1"
+    . "$ModulePath/Private/Test-StepperScriptRequirements.ps1"
+    . "$ModulePath/Private/Show-MoreDetails.ps1"
+    . "$ModulePath/Public/New-Step.ps1"
+
+    # Helper: create a minimal valid stepper script in $TestDrive.
+    # Returns a hashtable with Path, StatePath, and FirstStepLine.
+    function New-TestStepperScript {
+        param(
+            [string]$BaseName = "test-$(New-Guid)",
+            [int]$StepCount = 1,
+            [string[]]$ExtraLines = @()
+        )
+        $path = Join-Path $TestDrive "$BaseName.ps1"
+        $lines = @(
+            '#requires -Modules Stepper'
+            '[CmdletBinding()]'
+            'param()'
+        )
+        for ($i = 1; $i -le $StepCount; $i++) {
+            $lines += "New-Step { }"
+        }
+        foreach ($extra in $ExtraLines) {
+            $lines += $extra
+        }
+        $lines += 'Stop-Stepper'
+        Set-Content -Path $path -Value $lines
+        return @{
+            Path          = $path
+            StatePath     = Get-StepperStatePath -ScriptPath $path
+            FirstStepLine = 4  # line 1=requires, 2=CmdletBinding, 3=param, 4=first New-Step
+        }
+    }
+}
+
+Describe 'New-Step' -Tag 'Integration' {
+    BeforeAll {
+        Mock Write-Host {}
+        Mock Write-Verbose {}
+        Mock Test-StepperScriptRequirements { $false }
+        Mock Find-NewStepBlocks { [PSCustomObject]@{ NewStepBlocks = @(); StopStepperLine = -1 } }
+        Mock Find-UnmanagedCodeBlocks { @() }
+        Mock Show-MoreDetails {}
+    }
+
+    Context 'Parameter validation' {
+        It 'Accepts ScriptBlock as sole positional parameter (unnamed set)' {
+            $info = New-TestStepperScript
+            Mock Get-StepIdentifier { "$($info.Path):$($info.FirstStepLine)" }
+
+            { New-Step { } } | Should -Not -Throw
+        }
+
+        It 'Accepts Name and ScriptBlock as positional parameters (named set)' {
+            $info = New-TestStepperScript
+            Mock Get-StepIdentifier { "$($info.Path):$($info.FirstStepLine)" }
+
+            { New-Step 'My Step' { } } | Should -Not -Throw
+        }
+
+        It 'Throws StepIdentifierNotFound when Get-StepIdentifier fails' {
+            Mock Get-StepIdentifier { throw [System.InvalidOperationException]::new('no stack') }
+            $errors = @()
+            try {
+                New-Step { } -ErrorAction Stop
+            } catch {
+                $errors += $_
+            }
+            $errors | Where-Object { $_.FullyQualifiedErrorId -like 'StepIdentifierNotFound*' } | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Throws UnsavedScriptFile when script path does not exist' {
+            Mock Get-StepIdentifier { '/nonexistent/path/script.ps1:5' }
+            $errors = @()
+            try {
+                New-Step { } -ErrorAction Stop
+            } catch {
+                $errors += $_
+            }
+            $errors | Where-Object { $_.FullyQualifiedErrorId -like 'UnsavedScriptFile*' } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'ScriptBlock execution' {
+        BeforeEach {
+            $script:Info = New-TestStepperScript
+            Mock Get-StepIdentifier { "$($script:Info.Path):$($script:Info.FirstStepLine)" }
+        }
+
+        It 'Executes the ScriptBlock and produces a file side effect' {
+            $sideEffect = Join-Path $TestDrive "side-$(New-Guid).txt"
+            New-Step { Set-Content -Path $sideEffect -Value 'executed' }
+            $sideEffect | Should -Exist
+        }
+
+        It 'Creates a state file after successful execution' {
+            New-Step { }
+            $script:Info.StatePath | Should -Exist
+        }
+
+        It 'State contains the correct ScriptHash' {
+            New-Step { }
+            $state = Import-Clixml -Path $script:Info.StatePath
+            $expectedHash = Get-ScriptHash -ScriptPath $script:Info.Path
+            $state.ScriptHash | Should -Be $expectedHash
+        }
+
+        It 'State contains the correct LastCompletedStep identifier' {
+            New-Step { }
+            $state = Import-Clixml -Path $script:Info.StatePath
+            $state.LastCompletedStep | Should -Be "$($script:Info.Path):$($script:Info.FirstStepLine)"
+        }
+
+        It 'Does not create a state file when ScriptBlock throws' {
+            { New-Step { throw 'boom' } } | Should -Throw
+            $script:Info.StatePath | Should -Not -Exist
+        }
+
+        It 'Throws StepExecutionFailed when ScriptBlock throws' {
+            $errors = @()
+            try {
+                New-Step { throw 'boom' } -ErrorAction Stop
+            } catch {
+                $errors += $_
+            }
+            $errors | Where-Object { $_.FullyQualifiedErrorId -like 'StepExecutionFailed*' } | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Named step state persistence' {
+        BeforeEach {
+            $script:NamedInfo = New-TestStepperScript
+            Mock Get-StepIdentifier { "$($script:NamedInfo.Path):$($script:NamedInfo.FirstStepLine)" }
+        }
+
+        It 'State contains the correct step name for Named parameter set' {
+            New-Step 'Install Packages' { }
+            $state = Import-Clixml -Path $script:NamedInfo.StatePath
+            $state.LastCompletedStepName | Should -Be 'Install Packages'
+        }
+
+        It 'State contains null step name for unnamed parameter set' {
+            New-Step { }
+            $state = Import-Clixml -Path $script:NamedInfo.StatePath
+            $state.LastCompletedStepName | Should -BeNullOrEmpty
+        }
+
+        It 'State contains step number 1 for the first step' {
+            New-Step { }
+            $state = Import-Clixml -Path $script:NamedInfo.StatePath
+            $state.LastCompletedStepNumber | Should -Be 1
+        }
+    }
+
+    Context '$Stepper variable injection' {
+        BeforeEach {
+            $script:StepperVarInfo = New-TestStepperScript
+            Mock Get-StepIdentifier { "$($script:StepperVarInfo.Path):$($script:StepperVarInfo.FirstStepLine)" }
+            Remove-Variable -Name '__StepperInitialized' -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -ErrorAction SilentlyContinue
+        }
+
+        It 'StepperData is written to state after step executes' {
+            New-Step { }
+            $state = Import-Clixml -Path $script:StepperVarInfo.StatePath
+            $state.StepperData | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Sets StepName in StepperData for Named parameter set' {
+            New-Step 'Deploy App' { }
+            $state = Import-Clixml -Path $script:StepperVarInfo.StatePath
+            $state.StepperData['StepName'] | Should -Be 'Deploy App'
+        }
+
+        It 'Sets StepName to $null in StepperData for unnamed parameter set' {
+            New-Step { }
+            $state = Import-Clixml -Path $script:StepperVarInfo.StatePath
+            $state.StepperData.ContainsKey('StepName') | Should -BeTrue
+            $state.StepperData['StepName'] | Should -BeNullOrEmpty
+        }
+
+        It 'Sets StepNumber to 1 in StepperData for the first step' {
+            New-Step { }
+            $state = Import-Clixml -Path $script:StepperVarInfo.StatePath
+            $state.StepperData['StepNumber'] | Should -Be 1
+        }
+
+        It 'Persists custom $Stepper data across steps in the same execution' {
+            # Two-step script so step 2 has a valid identifier
+            $twoStepInfo = New-TestStepperScript -BaseName "twostep-$(New-Guid)" -StepCount 2
+            $callCount = 0
+            Mock Get-StepIdentifier {
+                $callCount++
+                if ($callCount -eq 1) {
+                    "$($twoStepInfo.Path):$($twoStepInfo.FirstStepLine)"
+                } else {
+                    "$($twoStepInfo.Path):$($twoStepInfo.FirstStepLine + 1)"
+                }
+            }
+
+            New-Step { $Stepper['MyKey'] = 'from-step-1' }
+            # Only verify the key was set during step 1 execution (side effect read from state)
+            $state = Import-Clixml -Path $twoStepInfo.StatePath
+            $state.StepperData['MyKey'] | Should -Be 'from-step-1'
+        }
+    }
+
+    Context 'Resume logic — script unchanged' {
+        BeforeEach {
+            # Two-step script: step 1 was completed, step 2 should run on resume
+            $script:ResumeInfo = New-TestStepperScript -BaseName "resume-$(New-Guid)" -StepCount 2
+            $step1Id = "$($script:ResumeInfo.Path):$($script:ResumeInfo.FirstStepLine)"
+            $scriptHash = Get-ScriptHash -ScriptPath $script:ResumeInfo.Path
+            Write-StepperState -StatePath $script:ResumeInfo.StatePath `
+                -ScriptHash $scriptHash `
+                -LastCompletedStep $step1Id `
+                -StepNumber 1
+
+            $script:ResumeCallCount = 0
+            Mock Get-StepIdentifier {
+                $script:ResumeCallCount++
+                if ($script:ResumeCallCount -eq 1) {
+                    "$($script:ResumeInfo.Path):$($script:ResumeInfo.FirstStepLine)"
+                } else {
+                    "$($script:ResumeInfo.Path):$($script:ResumeInfo.FirstStepLine + 1)"
+                }
+            }
+            Mock Read-Host { 'R' }
+
+            Remove-Variable -Name '__StepperInitialized' -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -ErrorAction SilentlyContinue
+        }
+
+        It 'Skips step 1 (already completed) — state not updated for skipped step' {
+            # Call step 1 (should be skipped). The state file should NOT be updated
+            # (no re-write for a skipped step). The pre-existing hash should still match.
+            New-Step { }
+            $state = Import-Clixml -Path $script:ResumeInfo.StatePath
+            $state.LastCompletedStep | Should -Be "$($script:ResumeInfo.Path):$($script:ResumeInfo.FirstStepLine)"
+        }
+
+        It 'Executes step 2 when called in resume mode with RestoreMode false' {
+            # Pre-configure execution state (simulates step 1 having been processed/skipped)
+            # so that New-Step for step 2 sees RestoreMode=false and executes
+            $script:ResumeCallCount = 1  # Get-StepIdentifier will return step2Id
+            $__StepperInitialized = $true
+            $__StepperExecutionState = @{
+                RestoreMode       = $false
+                TargetStep        = "$($script:ResumeInfo.Path):$($script:ResumeInfo.FirstStepLine)"
+                CurrentScriptPath = $script:ResumeInfo.Path
+                CurrentScriptHash = (Get-ScriptHash -ScriptPath $script:ResumeInfo.Path)
+                StatePath         = $script:ResumeInfo.StatePath
+            }
+
+            $sideEffect = Join-Path $TestDrive "step2-side-$(New-Guid).txt"
+            New-Step { Set-Content -Path $sideEffect -Value 'ran' }
+            $sideEffect | Should -Exist
+        }
+    }
+
+    Context 'Resume logic — Start over' {
+        BeforeEach {
+            $script:StartOverInfo = New-TestStepperScript -BaseName "startover-$(New-Guid)" -StepCount 2
+            $step1Id = "$($script:StartOverInfo.Path):$($script:StartOverInfo.FirstStepLine)"
+            $scriptHash = Get-ScriptHash -ScriptPath $script:StartOverInfo.Path
+            Write-StepperState -StatePath $script:StartOverInfo.StatePath `
+                -ScriptHash $scriptHash `
+                -LastCompletedStep $step1Id `
+                -StepNumber 1
+
+            $script:StartOverCallCount = 0
+            Mock Get-StepIdentifier {
+                $script:StartOverCallCount++
+                if ($script:StartOverCallCount -eq 1) {
+                    "$($script:StartOverInfo.Path):$($script:StartOverInfo.FirstStepLine)"
+                } else {
+                    "$($script:StartOverInfo.Path):$($script:StartOverInfo.FirstStepLine + 1)"
+                }
+            }
+            Mock Read-Host { 'S' }
+
+            Remove-Variable -Name '__StepperInitialized' -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -ErrorAction SilentlyContinue
+        }
+
+        It 'State after start over reflects step 1 completed (not resumed from prior)' {
+            # Pre-state says step 1 done; choose S; step 1 runs again; new state = step 1
+            New-Step { }
+            $state = Import-Clixml -Path $script:StartOverInfo.StatePath
+            $state.LastCompletedStepNumber | Should -Be 1
+            $state.LastCompletedStep | Should -Be "$($script:StartOverInfo.Path):$($script:StartOverInfo.FirstStepLine)"
+        }
+
+        It 'Executes step 1 again after Start over' {
+            $step1Executed = Join-Path $TestDrive "step1-$(New-Guid).txt"
+            New-Step { Set-Content -Path $step1Executed -Value 'ran' }
+            $step1Executed | Should -Exist
+        }
+    }
+
+    Context 'Resume logic — changed script defaults to Start over' {
+        BeforeEach {
+            $script:ChangedInfo = New-TestStepperScript -BaseName "changed-$(New-Guid)" -StepCount 2
+            $step1Id = "$($script:ChangedInfo.Path):$($script:ChangedInfo.FirstStepLine)"
+            # State was written with a DIFFERENT hash to simulate script modification
+            Write-StepperState -StatePath $script:ChangedInfo.StatePath `
+                -ScriptHash 'stale-hash-does-not-match' `
+                -LastCompletedStep $step1Id `
+                -StepNumber 1
+
+            $script:ChangedCallCount = 0
+            Mock Get-StepIdentifier {
+                $script:ChangedCallCount++
+                if ($script:ChangedCallCount -eq 1) {
+                    "$($script:ChangedInfo.Path):$($script:ChangedInfo.FirstStepLine)"
+                } else {
+                    "$($script:ChangedInfo.Path):$($script:ChangedInfo.FirstStepLine + 1)"
+                }
+            }
+            # Default (empty) response for changed script = Start over
+            Mock Read-Host { '' }
+
+            Remove-Variable -Name '__StepperInitialized' -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -ErrorAction SilentlyContinue
+        }
+
+        It 'State after start over reflects current hash (stale hash replaced)' {
+            New-Step { }
+            $state = Import-Clixml -Path $script:ChangedInfo.StatePath
+            $currentHash = Get-ScriptHash -ScriptPath $script:ChangedInfo.Path
+            $state.ScriptHash | Should -Be $currentHash
+        }
+
+        It 'Runs step 1 from scratch when starting over on changed script' {
+            $sideEffect = Join-Path $TestDrive "changed-side-$(New-Guid).txt"
+            New-Step { Set-Content -Path $sideEffect -Value 'ran' }
+            $sideEffect | Should -Exist
+        }
+    }
+
+    Context 'Missing Stop-Stepper — user chooses A (add)' {
+        BeforeEach {
+            # Script without Stop-Stepper
+            $script:NoStopPath = Join-Path $TestDrive "nostop-$(New-Guid).ps1"
+            Set-Content -Path $script:NoStopPath -Value @(
+                '#requires -Modules Stepper'
+                '[CmdletBinding()]'
+                'param()'
+                'New-Step { }'
+            )
+            Mock Get-StepIdentifier { "$($script:NoStopPath):4" }
+            Mock Read-Host { 'A' }
+            # Remove-StepperState fires right before `exit` in the A-path.
+            # Throwing here intercepts the exit so it never propagates and kills Pester.
+            Mock Remove-StepperState { throw [System.Exception]::new('Interrupted before exit') }
+
+            Remove-Variable -Name '__StepperInitialized' -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -ErrorAction SilentlyContinue
+        }
+
+        It 'Appends Stop-Stepper to the script file' {
+            try { New-Step { } } catch { }
+            $content = Get-Content -Path $script:NoStopPath -Raw
+            $content | Should -Match 'Stop-Stepper'
+        }
+    }
+
+    Context 'Missing Stop-Stepper — user chooses C (continue)' {
+        BeforeEach {
+            $script:NoStopContinuePath = Join-Path $TestDrive "nostop-c-$(New-Guid).ps1"
+            Set-Content -Path $script:NoStopContinuePath -Value @(
+                '#requires -Modules Stepper'
+                '[CmdletBinding()]'
+                'param()'
+                'New-Step { }'
+            )
+            Mock Get-StepIdentifier { "$($script:NoStopContinuePath):4" }
+            Mock Read-Host { 'C' }
+
+            Remove-Variable -Name '__StepperInitialized' -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -ErrorAction SilentlyContinue
+        }
+
+        It 'Creates a state file and does not modify the script' {
+            New-Step { }
+            $statePath = Get-StepperStatePath -ScriptPath $script:NoStopContinuePath
+            $statePath | Should -Exist
+            $content = Get-Content -Path $script:NoStopContinuePath -Raw
+            $content | Should -Not -Match 'Stop-Stepper'
+        }
+    }
+}

--- a/Tests/Read-StepperState.Tests.ps1
+++ b/Tests/Read-StepperState.Tests.ps1
@@ -1,0 +1,89 @@
+BeforeAll {
+    $ModulePath = Split-Path -Path $PSScriptRoot -Parent
+    . "$ModulePath/Private/Write-StepperState.ps1"
+    . "$ModulePath/Private/Read-StepperState.ps1"
+}
+
+Describe 'Read-StepperState' -Tag 'Unit' {
+    Context 'When state file does not exist' {
+        It 'Should return $null' {
+            $result = Read-StepperState -StatePath (Join-Path $TestDrive 'nonexistent.stepper')
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When state file exists and is valid' {
+        BeforeAll {
+            $script:ValidStatePath = Join-Path $TestDrive 'valid.stepper'
+            $writeParams = @{
+                StatePath         = $script:ValidStatePath
+                ScriptHash        = 'aabbccdd'
+                LastCompletedStep = '/tmp/script.ps1:15'
+                StepName          = 'Setup environment'
+                StepNumber        = 2
+                StepperData       = @{ Key1 = 'value1'; Num1 = 99 }
+                ScriptContents    = 'Write-Host "hello"'
+            }
+            Write-StepperState @writeParams
+            $script:State = Read-StepperState -StatePath $script:ValidStatePath
+        }
+
+        It 'Should return a non-null object on round-trip' {
+            $script:State | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should return an object with all expected properties' {
+            $props = $script:State.PSObject.Properties.Name
+            $props | Should -Contain 'ScriptHash'
+            $props | Should -Contain 'LastCompletedStep'
+            $props | Should -Contain 'LastCompletedStepName'
+            $props | Should -Contain 'LastCompletedStepNumber'
+            $props | Should -Contain 'Timestamp'
+            $props | Should -Contain 'StepperData'
+            $props | Should -Contain 'ScriptContents'
+        }
+
+        It 'Should return the correct ScriptHash' {
+            $script:State.ScriptHash | Should -Be 'aabbccdd'
+        }
+
+        It 'Should return the correct LastCompletedStep' {
+            $script:State.LastCompletedStep | Should -Be '/tmp/script.ps1:15'
+        }
+
+        It 'Should return the correct LastCompletedStepName' {
+            $script:State.LastCompletedStepName | Should -Be 'Setup environment'
+        }
+
+        It 'Should return the correct LastCompletedStepNumber' {
+            $script:State.LastCompletedStepNumber | Should -Be 2
+        }
+
+        It 'Should return the correct ScriptContents' {
+            $script:State.ScriptContents | Should -Be 'Write-Host "hello"'
+        }
+
+        It 'Should correctly deserialize StepperData hashtable values' {
+            $script:State.StepperData['Key1'] | Should -Be 'value1'
+            $script:State.StepperData['Num1'] | Should -Be 99
+        }
+    }
+
+    Context 'When state file contains corrupt XML' {
+        BeforeAll {
+            $script:CorruptPath = Join-Path $TestDrive 'corrupt.stepper'
+            Set-Content -Path $script:CorruptPath -Value '<<< NOT VALID XML >>>'
+        }
+
+        It 'Should return $null' {
+            $result = Read-StepperState -StatePath $script:CorruptPath -ErrorAction SilentlyContinue
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should write a non-terminating error with StateReadFailed error id' {
+            $errors = @()
+            Read-StepperState -StatePath $script:CorruptPath -ErrorVariable errors -ErrorAction SilentlyContinue
+            $errors | Where-Object { $_.FullyQualifiedErrorId -like 'StateReadFailed*' } | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Remove-StepperState.Tests.ps1
+++ b/Tests/Remove-StepperState.Tests.ps1
@@ -1,0 +1,36 @@
+BeforeAll {
+    $ModulePath = Split-Path -Path $PSScriptRoot -Parent
+    . "$ModulePath/Private/Remove-StepperState.ps1"
+}
+
+Describe 'Remove-StepperState' -Tag 'Unit' {
+    Context 'When state file exists' {
+        It 'Should remove the state file from disk' {
+            $statePath = Join-Path $TestDrive 'existing.stepper'
+            Set-Content -Path $statePath -Value 'state data'
+            Remove-StepperState -StatePath $statePath
+            $statePath | Should -Not -Exist
+        }
+    }
+
+    Context 'When state file does not exist' {
+        It 'Should not throw (idempotent)' {
+            $nonExistentPath = Join-Path $TestDrive 'ghost.stepper'
+            { Remove-StepperState -StatePath $nonExistentPath } | Should -Not -Throw
+        }
+    }
+
+    Context 'When Remove-Item fails' {
+        BeforeAll {
+            $script:LockedPath = Join-Path $TestDrive 'locked.stepper'
+            Set-Content -Path $script:LockedPath -Value 'state data'
+            Mock Remove-Item { throw [System.IO.IOException]::new('access denied') }
+        }
+
+        It 'Should write a non-terminating error with StateRemovalFailed error id' {
+            $errors = @()
+            Remove-StepperState -StatePath $script:LockedPath -ErrorVariable errors -ErrorAction SilentlyContinue
+            $errors | Where-Object { $_.FullyQualifiedErrorId -like 'StateRemovalFailed*' } | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Stop-Stepper.Tests.ps1
+++ b/Tests/Stop-Stepper.Tests.ps1
@@ -1,0 +1,202 @@
+BeforeAll {
+    $ModulePath = Split-Path -Path $PSScriptRoot -Parent
+    . "$ModulePath/Private/Get-StepperStatePath.ps1"
+    . "$ModulePath/Private/Write-StepperState.ps1"
+    . "$ModulePath/Private/Read-StepperState.ps1"
+    . "$ModulePath/Private/Remove-StepperState.ps1"
+    . "$ModulePath/Public/Stop-Stepper.ps1"
+
+    # On macOS, $TestDrive resolves to /private/tmp/… which matches the
+    # */Private/*.ps1 path filter in Stop-Stepper (case-insensitive -like).
+    # Use the test file's own path as the fake "user script" ScriptName — it
+    # lives in Tests/ and will never match Private/, Public/, or Stepper.psm1.
+    $script:FakeUserScript = Join-Path $PSScriptRoot 'Stop-Stepper.Tests.ps1'
+    $script:FakeStatePath  = Get-StepperStatePath -ScriptPath $script:FakeUserScript
+}
+
+Describe 'Stop-Stepper' -Tag 'Integration' {
+    BeforeAll {
+        Mock Write-Host {}
+        Mock Write-Verbose {}
+    }
+
+    AfterEach {
+        Remove-Item -Path $script:FakeStatePath -ErrorAction SilentlyContinue
+    }
+
+    Context 'When state file exists for the calling script' {
+        BeforeEach {
+            Write-StepperState -StatePath $script:FakeStatePath -ScriptHash 'abc123' `
+                -LastCompletedStep "${script:FakeUserScript}:1"
+
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $modulePath = $ModulePath
+            $fakeUser  = $script:FakeUserScript
+            $frames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${modulePath}${sep}Public${sep}Stop-Stepper.ps1"
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $fakeUser
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack -MockWith { $frames }.GetNewClosure()
+        }
+
+        It 'Removes the state file' {
+            Stop-Stepper
+            $script:FakeStatePath | Should -Not -Exist
+        }
+    }
+
+    Context 'When no state file exists' {
+        BeforeEach {
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $modulePath = $ModulePath
+            $fakeUser  = $script:FakeUserScript
+            $frames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${modulePath}${sep}Public${sep}Stop-Stepper.ps1"
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $fakeUser
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack -MockWith { $frames }.GetNewClosure()
+        }
+
+        It 'Does not throw' {
+            { Stop-Stepper } | Should -Not -Throw
+        }
+    }
+
+    Context 'When call stack has only module frames' {
+        BeforeEach {
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $modulePath = $ModulePath
+            $frames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${modulePath}${sep}Public${sep}Stop-Stepper.ps1"
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack -MockWith { $frames }.GetNewClosure()
+        }
+
+        It 'Writes a warning about unable to determine script path' {
+            Mock Write-Warning {}
+            Stop-Stepper
+            Should -Invoke Write-Warning -Exactly 1 -ParameterFilter {
+                $Message -like '*Unable to determine*'
+            } -Scope It
+        }
+    }
+
+    Context 'When call stack includes mixed module frames before user script' {
+        BeforeEach {
+            Write-StepperState -StatePath $script:FakeStatePath -ScriptHash 'abc' `
+                -LastCompletedStep "${script:FakeUserScript}:1"
+
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $modulePath = $ModulePath
+            $fakeUser  = $script:FakeUserScript
+            $frames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${modulePath}${sep}Public${sep}Stop-Stepper.ps1"
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = "${modulePath}${sep}Private${sep}Some-Helper.ps1"
+                    ScriptLineNumber = 5
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = "${modulePath}${sep}Stepper.psm1"
+                    ScriptLineNumber = 10
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $fakeUser
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack -MockWith { $frames }.GetNewClosure()
+        }
+
+        It 'Skips all module frames and finds the user script' {
+            Stop-Stepper
+            $script:FakeStatePath | Should -Not -Exist
+        }
+    }
+
+    Context 'When script path falls back to __StepperExecutionState' {
+        BeforeEach {
+            Write-StepperState -StatePath $script:FakeStatePath -ScriptHash 'abc' `
+                -LastCompletedStep "${script:FakeUserScript}:1"
+
+            # Return only module frames — forces fallback to __StepperExecutionState
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $modulePath = $ModulePath
+            $frames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${modulePath}${sep}Public${sep}Stop-Stepper.ps1"
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack -MockWith { $frames }.GetNewClosure()
+
+            # Inject __StepperExecutionState into the current scope so Stop-Stepper's
+            # $PSCmdlet.SessionState can find it
+            $__StepperExecutionState = @{ CurrentScriptPath = $script:FakeUserScript }
+        }
+
+        It 'Resolves script path from __StepperExecutionState and removes state file' {
+            Stop-Stepper
+            $script:FakeStatePath | Should -Not -Exist
+        }
+    }
+
+    Context 'When state removal throws' {
+        BeforeEach {
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $modulePath = $ModulePath
+            $fakeUser  = $script:FakeUserScript
+            $frames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${modulePath}${sep}Public${sep}Stop-Stepper.ps1"
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $fakeUser
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack -MockWith { $frames }.GetNewClosure()
+            Mock Remove-StepperState { throw 'simulated permission denied' }
+        }
+
+        It 'Writes a non-terminating error' {
+            Mock Write-Error {}
+            Stop-Stepper
+            Should -Invoke Write-Error -Exactly 1 -Scope It
+        }
+
+        It 'Does not rethrow' {
+            { Stop-Stepper } | Should -Not -Throw
+        }
+    }
+}

--- a/Tests/Test-StepperScriptRequirements.Tests.ps1
+++ b/Tests/Test-StepperScriptRequirements.Tests.ps1
@@ -1,0 +1,180 @@
+BeforeAll {
+    $ModulePath = Split-Path -Path $PSScriptRoot -Parent
+    . "$ModulePath/Private/Get-StepperStatePath.ps1"
+    . "$ModulePath/Private/Remove-StepperState.ps1"
+    . "$ModulePath/Private/Test-StepperScriptRequirements.ps1"
+}
+
+Describe 'Test-StepperScriptRequirements' -Tag 'Unit' {
+    BeforeAll {
+        Mock Write-Host {}
+        Mock Read-Host { 'S' }
+    }
+
+    Context 'When script already has both declarations' {
+        BeforeEach {
+            $script:ScriptPath = Join-Path $TestDrive "complete-$(New-Guid).ps1"
+            Set-Content -Path $script:ScriptPath -Value @(
+                '#requires -Modules Stepper'
+                '[CmdletBinding()]'
+                'param()'
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+        }
+
+        It 'Should return $false' {
+            $result = Test-StepperScriptRequirements -ScriptPath $script:ScriptPath
+            $result | Should -BeFalse
+        }
+
+        It 'Should not prompt the user' {
+            Test-StepperScriptRequirements -ScriptPath $script:ScriptPath
+            Should -Invoke Read-Host -Exactly 0 -Scope It
+        }
+    }
+
+    Context 'When [CmdletBinding()] is missing' {
+        It 'Should prompt the user' {
+            $scriptPath = Join-Path $TestDrive "missing-cb-$(New-Guid).ps1"
+            Set-Content -Path $scriptPath -Value @(
+                '#requires -Modules Stepper'
+                'param()'
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+            Test-StepperScriptRequirements -ScriptPath $scriptPath
+            Should -Invoke Read-Host -Exactly 1 -Scope It
+        }
+    }
+
+    Context 'When #requires -Modules Stepper is missing' {
+        It 'Should prompt the user' {
+            $scriptPath = Join-Path $TestDrive "missing-req-$(New-Guid).ps1"
+            Set-Content -Path $scriptPath -Value @(
+                '[CmdletBinding()]'
+                'param()'
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+            Test-StepperScriptRequirements -ScriptPath $scriptPath
+            Should -Invoke Read-Host -Exactly 1 -Scope It
+        }
+    }
+
+    Context 'When user chooses A (add declarations)' {
+        BeforeAll {
+            Mock Read-Host { 'A' }
+            $script:AddPath = Join-Path $TestDrive "add-a-$(New-Guid).ps1"
+            Set-Content -Path $script:AddPath -Value @(
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+            $script:AddResult = Test-StepperScriptRequirements -ScriptPath $script:AddPath
+            $script:AddContent = Get-Content -Path $script:AddPath -Raw
+        }
+
+        It 'Should return $true' {
+            $script:AddResult | Should -BeTrue
+        }
+
+        It 'Should add #requires -Modules Stepper to the file' {
+            $script:AddContent | Should -Match '(?i)#requires\s+-Modules?\s+Stepper'
+        }
+
+        It 'Should add [CmdletBinding()] to the file' {
+            $script:AddContent | Should -Match '\[CmdletBinding\(\)\]'
+        }
+    }
+
+    Context 'When user chooses S (skip)' {
+        It 'Should return $false' {
+            $scriptPath = Join-Path $TestDrive "skip-$(New-Guid).ps1"
+            Set-Content -Path $scriptPath -Value @(
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+            $result = Test-StepperScriptRequirements -ScriptPath $scriptPath
+            $result | Should -BeFalse
+        }
+
+        It 'Should leave the file unmodified' {
+            $scriptPath = Join-Path $TestDrive "skip-hash-$(New-Guid).ps1"
+            Set-Content -Path $scriptPath -Value @(
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+            $originalHash = (Get-FileHash -Path $scriptPath).Hash
+            Test-StepperScriptRequirements -ScriptPath $scriptPath
+            (Get-FileHash -Path $scriptPath).Hash | Should -Be $originalHash
+        }
+    }
+
+    Context 'When script starts with a shebang and comments' {
+        It 'Should insert declarations after shebang and comments, before first code' {
+            $scriptPath = Join-Path $TestDrive "shebang-$(New-Guid).ps1"
+            Set-Content -Path $scriptPath -Value @(
+                '#!/usr/bin/env pwsh'
+                '# My script comment'
+                ''
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+            Mock Read-Host { 'A' }
+            Test-StepperScriptRequirements -ScriptPath $scriptPath
+            $lines = Get-Content -Path $scriptPath
+            $commentIdx = [array]::IndexOf($lines, '# My script comment')
+            $requiresIdx = ($lines | Select-String '(?i)#requires').LineNumber - 1
+            $stepIdx = [array]::IndexOf($lines, 'New-Step { Write-Host "step" }')
+            $requiresIdx | Should -BeGreaterThan $commentIdx
+            $requiresIdx | Should -BeLessThan $stepIdx
+        }
+    }
+
+    Context 'When script already has a param() block' {
+        It 'Should not duplicate param()' {
+            $scriptPath = Join-Path $TestDrive "has-param-$(New-Guid).ps1"
+            Set-Content -Path $scriptPath -Value @(
+                '#requires -Modules Stepper'
+                'param()'
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+            Mock Read-Host { 'A' }
+            Test-StepperScriptRequirements -ScriptPath $scriptPath
+            $lines = Get-Content -Path $scriptPath
+            $paramCount = ($lines | Where-Object { $_ -match '^\s*param\s*\(\s*\)\s*$' }).Count
+            $paramCount | Should -Be 1
+        }
+    }
+
+    Context 'When #requires uses different casing or -Module (singular)' {
+        It 'Should recognize #Requires -Module Stepper as satisfying the requirement' {
+            $scriptPath = Join-Path $TestDrive "requires-case-$(New-Guid).ps1"
+            Set-Content -Path $scriptPath -Value @(
+                '#Requires -Module Stepper'
+                '[CmdletBinding()]'
+                'param()'
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+            $result = Test-StepperScriptRequirements -ScriptPath $scriptPath
+            $result | Should -BeFalse
+        }
+    }
+
+    Context 'When declarations are added and a state file exists' {
+        It 'Should delete the state file' {
+            $scriptPath = Join-Path $TestDrive "state-delete-$(New-Guid).ps1"
+            Set-Content -Path $scriptPath -Value @(
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+            $statePath = Get-StepperStatePath -ScriptPath $scriptPath
+            Set-Content -Path $statePath -Value 'dummy state'
+            Mock Read-Host { 'A' }
+            Test-StepperScriptRequirements -ScriptPath $scriptPath
+            $statePath | Should -Not -Exist
+        }
+    }
+}

--- a/Tests/Update-ScriptWithUnmanagedActions.Tests.ps1
+++ b/Tests/Update-ScriptWithUnmanagedActions.Tests.ps1
@@ -1,0 +1,194 @@
+BeforeAll {
+    $ModulePath = Split-Path -Path $PSScriptRoot -Parent
+    . "$ModulePath/Private/Get-StepperStatePath.ps1"
+    . "$ModulePath/Private/Remove-StepperState.ps1"
+    . "$ModulePath/Private/Update-ScriptWithUnmanagedActions.ps1"
+}
+
+Describe 'Update-ScriptWithUnmanagedActions' -Tag 'Unit' {
+    BeforeAll {
+        Mock Write-Host {}
+    }
+
+    Context 'Wrap action' {
+        It 'Should wrap a single line in a New-Step block with 4-space indent' {
+            $scriptPath = Join-Path $TestDrive "wrap-$(New-Guid).ps1"
+            $lines = @(
+                'Write-Host "unmanaged"',
+                'New-Step {',
+                '    Write-Host "step"',
+                '}',
+                'Stop-Stepper'
+            )
+            Set-Content -Path $scriptPath -Value $lines
+            $actions = @{ 0 = @{ Action = 'Wrap' } }
+
+            Update-ScriptWithUnmanagedActions -ScriptPath $scriptPath -ScriptLines $lines -Actions $actions -NewStepBlocks @()
+
+            $result = Get-Content -Path $scriptPath
+            $result | Should -Contain 'New-Step {'
+            $result | Should -Contain '    Write-Host "unmanaged"'
+            $result | Should -Contain '}'
+        }
+    }
+
+    Context 'MarkIgnored action' {
+        It 'Should wrap a single line in a Stepper ignore region' {
+            $scriptPath = Join-Path $TestDrive "ignore-$(New-Guid).ps1"
+            $lines = @(
+                'Write-Host "unmanaged"',
+                'New-Step {',
+                '    Write-Host "step"',
+                '}',
+                'Stop-Stepper'
+            )
+            Set-Content -Path $scriptPath -Value $lines
+            $actions = @{ 0 = @{ Action = 'MarkIgnored' } }
+
+            Update-ScriptWithUnmanagedActions -ScriptPath $scriptPath -ScriptLines $lines -Actions $actions -NewStepBlocks @()
+
+            $result = Get-Content -Path $scriptPath
+            $result | Should -Contain '#region Stepper ignore'
+            $result | Should -Contain 'Write-Host "unmanaged"'
+            $result | Should -Contain '#endregion Stepper ignore'
+        }
+    }
+
+    Context 'Delete action' {
+        It 'Should remove the specified line from the output' {
+            $scriptPath = Join-Path $TestDrive "delete-$(New-Guid).ps1"
+            $lines = @(
+                'Write-Host "remove me"',
+                'New-Step {',
+                '    Write-Host "step"',
+                '}',
+                'Stop-Stepper'
+            )
+            Set-Content -Path $scriptPath -Value $lines
+            $actions = @{ 0 = @{ Action = 'Delete' } }
+
+            Update-ScriptWithUnmanagedActions -ScriptPath $scriptPath -ScriptLines $lines -Actions $actions -NewStepBlocks @()
+
+            $result = Get-Content -Path $scriptPath
+            $result | Should -Not -Contain 'Write-Host "remove me"'
+        }
+    }
+
+    Context 'Non-actioned lines' {
+        It 'Should preserve non-actioned lines exactly' {
+            $scriptPath = Join-Path $TestDrive "preserve-$(New-Guid).ps1"
+            $lines = @(
+                'Write-Host "delete me"',
+                'Write-Host "keep me exactly"',
+                'Stop-Stepper'
+            )
+            Set-Content -Path $scriptPath -Value $lines
+            $actions = @{ 0 = @{ Action = 'Delete' } }
+
+            Update-ScriptWithUnmanagedActions -ScriptPath $scriptPath -ScriptLines $lines -Actions $actions -NewStepBlocks @()
+
+            $result = Get-Content -Path $scriptPath
+            $result | Should -Contain 'Write-Host "keep me exactly"'
+            $result | Should -Contain 'Stop-Stepper'
+        }
+    }
+
+    Context 'Consecutive lines grouped into a single block' {
+        It 'Should wrap consecutive Wrap lines in a single New-Step block' {
+            $scriptPath = Join-Path $TestDrive "consec-wrap-$(New-Guid).ps1"
+            $lines = @(
+                'Write-Host "line0"',
+                'Write-Host "line1"',
+                'Stop-Stepper'
+            )
+            Set-Content -Path $scriptPath -Value $lines
+            $actions = @{
+                0 = @{ Action = 'Wrap' }
+                1 = @{ Action = 'Wrap' }
+            }
+
+            Update-ScriptWithUnmanagedActions -ScriptPath $scriptPath -ScriptLines $lines -Actions $actions -NewStepBlocks @()
+
+            $result = Get-Content -Path $scriptPath
+            ($result | Where-Object { $_ -eq 'New-Step {' }) | Should -HaveCount 1
+        }
+
+        It 'Should wrap consecutive MarkIgnored lines in a single region block' {
+            $scriptPath = Join-Path $TestDrive "consec-ignore-$(New-Guid).ps1"
+            $lines = @(
+                'Write-Host "line0"',
+                'Write-Host "line1"',
+                'Stop-Stepper'
+            )
+            Set-Content -Path $scriptPath -Value $lines
+            $actions = @{
+                0 = @{ Action = 'MarkIgnored' }
+                1 = @{ Action = 'MarkIgnored' }
+            }
+
+            Update-ScriptWithUnmanagedActions -ScriptPath $scriptPath -ScriptLines $lines -Actions $actions -NewStepBlocks @()
+
+            $result = Get-Content -Path $scriptPath
+            ($result | Where-Object { $_ -eq '#region Stepper ignore' }) | Should -HaveCount 1
+        }
+    }
+
+    Context 'Multiple non-adjacent action groups' {
+        It 'Should handle multiple non-adjacent groups correctly in one pass' {
+            $scriptPath = Join-Path $TestDrive "multi-$(New-Guid).ps1"
+            $lines = @(
+                'Write-Host "wrap-me"',
+                'New-Step { Write-Host "step" }',
+                'Write-Host "ignore-me"',
+                'Stop-Stepper'
+            )
+            Set-Content -Path $scriptPath -Value $lines
+            $actions = @{
+                0 = @{ Action = 'Wrap' }
+                2 = @{ Action = 'MarkIgnored' }
+            }
+
+            Update-ScriptWithUnmanagedActions -ScriptPath $scriptPath -ScriptLines $lines -Actions $actions -NewStepBlocks @()
+
+            $result = Get-Content -Path $scriptPath
+            $result | Should -Contain 'New-Step {'
+            $result | Should -Contain '    Write-Host "wrap-me"'
+            $result | Should -Contain '#region Stepper ignore'
+            $result | Should -Contain 'Write-Host "ignore-me"'
+            $result | Should -Contain '#endregion Stepper ignore'
+        }
+    }
+
+    Context 'State file cleanup' {
+        It 'Should delete the state file after modifying the script' {
+            $scriptPath = Join-Path $TestDrive "state-$(New-Guid).ps1"
+            $lines = @(
+                'Write-Host "delete me"',
+                'Stop-Stepper'
+            )
+            Set-Content -Path $scriptPath -Value $lines
+            $statePath = Get-StepperStatePath -ScriptPath $scriptPath
+            Set-Content -Path $statePath -Value 'dummy state'
+            $actions = @{ 0 = @{ Action = 'Delete' } }
+
+            Update-ScriptWithUnmanagedActions -ScriptPath $scriptPath -ScriptLines $lines -Actions $actions -NewStepBlocks @()
+
+            $statePath | Should -Not -Exist
+        }
+    }
+
+    Context 'Write failure' {
+        BeforeAll {
+            Mock Set-Content { throw [System.IO.IOException]::new('disk full') }
+        }
+
+        It 'Should throw a terminating error with ScriptWriteFailed error id' {
+            $scriptPath = Join-Path $TestDrive 'error.ps1'
+            $lines = @('Write-Host "test"', 'Stop-Stepper')
+            $actions = @{ 0 = @{ Action = 'Delete' } }
+
+            { Update-ScriptWithUnmanagedActions -ScriptPath $scriptPath -ScriptLines $lines -Actions $actions -NewStepBlocks @() } |
+                Should -Throw -ErrorId 'ScriptWriteFailed*'
+        }
+    }
+}

--- a/Tests/Write-StepperState.Tests.ps1
+++ b/Tests/Write-StepperState.Tests.ps1
@@ -1,0 +1,80 @@
+BeforeAll {
+    $ModulePath = Split-Path -Path $PSScriptRoot -Parent
+    . "$ModulePath/Private/Write-StepperState.ps1"
+}
+
+Describe 'Write-StepperState' -Tag 'Unit' {
+    Context 'When writing valid state to disk' {
+        BeforeEach {
+            $StatePath = Join-Path $TestDrive "state-$(New-Guid).stepper"
+        }
+
+        It 'Should create a file at the specified path' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc123' -LastCompletedStep '/tmp/test.ps1:10'
+            $StatePath | Should -Exist
+        }
+
+        It 'Should write the correct ScriptHash' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'deadbeef01234567' -LastCompletedStep '/tmp/test.ps1:10'
+            $state = Import-Clixml -Path $StatePath
+            $state.ScriptHash | Should -Be 'deadbeef01234567'
+        }
+
+        It 'Should write the correct LastCompletedStep identifier' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:42'
+            $state = Import-Clixml -Path $StatePath
+            $state.LastCompletedStep | Should -Be '/tmp/test.ps1:42'
+        }
+
+        It 'Should write the correct LastCompletedStepName' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10' -StepName 'Install packages'
+            $state = Import-Clixml -Path $StatePath
+            $state.LastCompletedStepName | Should -Be 'Install packages'
+        }
+
+        It 'Should write the correct LastCompletedStepNumber' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10' -StepNumber 3
+            $state = Import-Clixml -Path $StatePath
+            $state.LastCompletedStepNumber | Should -Be 3
+        }
+
+        It 'Should preserve StepperData hashtable with mixed types' {
+            $data = @{
+                StringVal = 'hello'
+                IntVal    = 42
+                DateVal   = [datetime]::Parse('2026-01-15T10:30:00')
+            }
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10' -StepperData $data
+            $state = Import-Clixml -Path $StatePath
+            $state.StepperData['StringVal'] | Should -Be 'hello'
+            $state.StepperData['IntVal'] | Should -Be 42
+            $state.StepperData['DateVal'] | Should -BeOfType [datetime]
+        }
+
+        It 'Should include an ISO 8601 Timestamp' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10'
+            $state = Import-Clixml -Path $StatePath
+            $state.Timestamp | Should -Match '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'
+        }
+
+        It 'Should include ScriptContents when provided' {
+            $contents = 'Write-Host "hello"'
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10' -ScriptContents $contents
+            $state = Import-Clixml -Path $StatePath
+            $state.ScriptContents | Should -Be $contents
+        }
+    }
+
+    Context 'When Export-Clixml fails' {
+        BeforeAll {
+            Mock Export-Clixml { throw [System.IO.IOException]::new('simulated disk error') }
+        }
+
+        It 'Should write a non-terminating error with StateWriteFailed error id' {
+            $errors = @()
+            $failPath = Join-Path $TestDrive 'fail.stepper'
+            Write-StepperState -StatePath $failPath -ScriptHash 'abc' -LastCompletedStep 'x:1' -ErrorVariable errors -ErrorAction SilentlyContinue
+            $errors | Where-Object { $_.FullyQualifiedErrorId -like 'StateWriteFailed*' } | Should -Not -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
Adds 8 new test files covering Phases 2–4 of the planned test suite, bringing the total to 127 passing tests across all Stepper private and public functions.

## Changes

### Phase 2 — State management (file I/O)
- `Write-StepperState.Tests.ps1` — serialization, hash, step name/number, StepperData, timestamp, ScriptContents, write failure error
- `Read-StepperState.Tests.ps1` — deserialization, missing-file null return, corrupt-file error
- `Remove-StepperState.Tests.ps1` — deletion, no-throw on missing, removal failure error
- `Write-StepperState.Tests.ps1` — state writeback on requirements fix, stale state cleanup

### Phase 3 — Script validation
- `Test-StepperScriptRequirements.Tests.ps1` — `#Requires`, `[CmdletBinding()]`, `param()` detection and injection; state cleanup on modification
- `Update-ScriptWithUnmanagedActions.Tests.ps1` — Wrap/MarkIgnored/Delete actions, consecutive line grouping, multi-group handling, state cleanup, write failure error

### Phase 4 — Public API integration
- `Get-StepIdentifier.Tests.ps1` — call-stack introspection, Private/Public/module frame skipping, `StepIdentifierNotDetermined` error
- `Stop-Stepper.Tests.ps1` — state file removal, missing-state no-throw, unresolvable-path warning, module frame filtering, `__StepperExecutionState` fallback, removal failure error
- `New-Step.Tests.ps1` — parameter sets, scriptblock execution, state persistence, `$Stepper` data injection, resume logic, start-over, changed-script detection, missing `Stop-Stepper` Add/Continue flows

### Build
- Bump module version
- Fix `PSPublishModule` installation in build script