### PR TITLE
fix(tests): mock Write-Error in Stop-Stepper 'Does not rethrow' test

### DIFF
--- a/Tests/Stop-Stepper.Tests.ps1
+++ b/Tests/Stop-Stepper.Tests.ps1
@@ -196,6 +196,7 @@ Describe 'Stop-Stepper' -Tag 'Integration' {
         }
 
         It 'Does not rethrow' {
+            Mock Write-Error {}
             { Stop-Stepper } | Should -Not -Throw
         }
     }


### PR DESCRIPTION
- Pester -CI mode (used in GitHub Actions) sets $ErrorActionPreference = 'Stop' globally
- Write-Error inside catch block becomes terminating under Stop preference
- 'Does not rethrow' test was failing in CI but passing locally
- Add Mock Write-Error {} to isolate the no-rethrow assertion from error emission