### PR TITLE
Restrict PSPublishModule installation to version 2.0.27

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         Write-Host "Installing required modules..." -ForegroundColor Cyan
         Install-Module -Name Pester -AllowClobber -Scope CurrentUser -SkipPublisherCheck -Force
         Install-Module -Name PSScriptAnalyzer -AllowClobber -Scope CurrentUser -Force
-        Install-Module -Name PSPublishModule -AllowClobber -Scope CurrentUser -Force
+        Install-Module -Name PSPublishModule -AllowClobber -MaximumVersion 2.0.27 -Scope CurrentUser -Force
         Write-Host "Modules installed successfully" -ForegroundColor Green
 
     - name: Run Pester tests


### PR DESCRIPTION
PSPublishModule 3.0.x is breaking the build. Pinning to 2.0.27 for now.