### PR TITLE
feat(logging): add structured logging and per-step transcripts (#39)

### DIFF
--- a/Docs/adr/0002-logging-and-step-transcripts.md
+++ b/Docs/adr/0002-logging-and-step-transcripts.md
@@ -1,0 +1,81 @@
+# ADR 0002: Logging and Step Transcripts
+
+**Date:** 2026-04-19
+**Status:** Accepted
+**Deciders:** Jake Hildreth
+
+---
+
+## Context
+
+Stepper had no persistent log output. All status information was emitted via `Write-Verbose`, which is ephemeral — lost if the caller omits `-Verbose` or does not capture output. There was no record of step runtimes, step failures, or what happened during a previous run.
+
+Three design questions required explicit decisions before implementation:
+
+1. **Should logging be opt-in or opt-out?** Opt-in (e.g., requiring `-LogPath` on every step) is verbose and error-prone. Opt-out (logging on by default) is safer for unattended scripts.
+2. **How should within-step command output be captured?** Stream redirection, verbose-only, or native PS transcripts.
+3. **Where should the log file be stored?** Alongside the script, in a user-specified path, or somewhere else.
+
+---
+
+## Decision
+
+### Logging is on by default; opt out with `-NoLog`
+
+Logging is enabled for every step unless the user explicitly passes `-NoLog` to a `New-Step` call. When `-NoLog` is present on any step, Stepper prompts the user at init time to choose scope:
+
+- **A** — log all steps (ignore `-NoLog` flags)
+- **S** — skip logging for the flagged steps only
+- **N** — disable logging entirely
+
+This decision is persisted in the `.stepper` state file so resumed runs do not re-prompt.
+
+Rationale: unattended scripts need logs most — requiring an explicit opt-in means logs are missing exactly when they're most needed.
+
+### Native `Start-Transcript` per step, folded into the log file
+
+Each step is wrapped with `Start-Transcript`/`Stop-Transcript` writing to a temp file. After the step completes (or fails), the transcript content is appended to the structured log file between `=== BEGIN STEP N TRANSCRIPT ===` / `=== END STEP N TRANSCRIPT ===` delimiters.
+
+Rationale: `Start-Transcript` captures the full host output including `Write-Host` in both PS 5.1 and PS Core. Stream redirection (`6>&1 5>&1 ...`) does not capture `Write-Host` in PS 5.1 and produces interleaved `InformationRecord` objects rather than readable text.
+
+### Active transcript detection is a hard stop
+
+Before starting a per-step transcript, Stepper checks `$Host.UI.IsTranscribing`. If `$true`, it emits a clear user-facing message and throws a terminating error (`TranscriptAlreadyActive`, category `ResourceBusy`). It does not silently skip transcript capture and continue.
+
+Rationale: silently skipping produces a log with missing transcript sections — worse than a clear failure because the user may not notice. A hard stop with an actionable message (`Stop-Transcript and re-run`) is unambiguous.
+
+### Default log path: `scriptname.ps1.stepper.log` alongside the script
+
+If no `-LogPath` is specified on any `New-Step` call, the log is written to the same directory as the script with the filename `<scriptname>.ps1.stepper.log`. This keeps all Stepper-owned files co-located and identifiable (`.stepper` state + `.stepper.log` log).
+
+If one or more `New-Step` calls specify `-LogPath` with a static string, that path is used. If multiple calls specify different paths, Stepper prompts the user to choose (non-interactive default: first seen + `Write-Warning`). Dynamic paths (variables) cannot be resolved at AST-scan time; the first runtime value wins and a `Write-Warning` is emitted if a subsequent call provides a different value.
+
+### Log config persisted in `.stepper` state file
+
+`LogPath`, `LoggingEnabled`, and `NoLogStepIds` are added to the existing `Export-Clixml` state object. On a resumed run, these values are read from state and applied without re-prompting.
+
+Rationale: consistency — the path and scope decisions made on the first run should apply to the resumed run, which may be unattended.
+
+---
+
+## Consequences
+
+- **New private functions:** `Write-StepperLog` (structured log helper), `Get-StepLogConfig` (AST scan for `-LogPath` and `-NoLog` across all steps)
+- **State schema change:** three new fields (`LogPath`, `LoggingEnabled`, `NoLogStepIds`) added to the `Export-Clixml` object in `Write-StepperState.ps1`. Backwards compatible — old state files simply lack these fields (treated as `$null`/`$false`).
+- **`New-Step` new params:** `-LogPath [string]`, `-NoLog [switch]`
+- **`Stop-Stepper` no new params:** reads `LogPath` from `__StepperExecutionState` in the calling scope; no user-facing change.
+- **Temp files:** one temp file per step execution, deleted in a `finally` block. If the process is killed mid-step, the temp file may be orphaned in `$env:TEMP` — acceptable.
+- **PS 5.1 + active transcript:** hard stop with `TranscriptAlreadyActive`. Users running enterprise runbooks that pre-start transcripts must stop them before using Stepper logging. `-NoLog` on all steps or `-N` at the scope prompt is the workaround.
+- **`Read-Host` not captured in transcripts on Unix/macOS:** `Start-Transcript` on PS Core (Unix/macOS) does not capture `Read-Host` prompts or their responses. Pipeline output, `Write-Host`, and `Write-Output` are captured normally. This is a `Start-Transcript` platform limitation — not a Stepper defect. On Windows (PS 5.1 or PS 7), `Read-Host` prompts are captured.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Reason Rejected |
+|---|---|
+| Opt-in logging via `-LogPath` on every step | Verbose, error-prone; logs missing in unattended scenarios |
+| Stream redirection (`6>&1 5>&1 2>&1`) | Does not capture `Write-Host` in PS 5.1 |
+| Separate transcript file per step | Adds file proliferation; structured log + sections is more readable |
+| `Set-StepperConfig` module-level cmdlet | Adds a new public API for a problem already solved by per-step params + state persistence |
+| Silent skip on active transcript | Produces silently incomplete logs; hard stop is safer and more honest |

--- a/Docs/api-reference.md
+++ b/Docs/api-reference.md
@@ -5,16 +5,20 @@
 Executes a step in a resumable script. Tracks state by `filepath:lineNumber`.
 
 ```powershell
-New-Step [-Name] <string> [-ScriptBlock] <scriptblock>
-New-Step [-ScriptBlock] <scriptblock>
+New-Step [-Name] <string> [-ScriptBlock] <scriptblock> [-LogPath <string>] [-NoLog]
+New-Step [-ScriptBlock] <scriptblock> [-LogPath <string>] [-NoLog]
 ```
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `Name` | `string` | No | Display name shown in prompts and verbose output |
 | `ScriptBlock` | `scriptblock` | Yes | The code to execute |
+| `LogPath` | `string` | No | Path to the log file. Overrides the default (`<scriptname>.ps1.stepper.log`). Only needs to be specified once — Stepper resolves it via AST scan at init time. |
+| `NoLog` | `switch` | No | Exclude this step from logging. At init time Stepper prompts to choose scope: log all / skip flagged / disable entirely. |
 
 Must be called from a saved `.ps1` file. Does not work from the console or an unsaved editor buffer.
+
+See [Logging](logging.md) for full details on log format, step transcripts, and active transcript conflict handling.
 
 ## `Stop-Stepper`
 

--- a/Docs/data-persistence.md
+++ b/Docs/data-persistence.md
@@ -40,6 +40,9 @@ Stepper stores state in `<scriptname>.ps1.stepper` alongside the script, using P
 | `LastCompletedStepNumber` | 1-based step index |
 | `Timestamp` | ISO 8601 datetime |
 | `StepperData` | Serialized `$Stepper` hashtable |
+| `LogPath` | Resolved path to the log file, or `$null` if logging is disabled |
+| `LoggingEnabled` | `$true` unless the user chose `[N]` at the scope prompt |
+| `NoLogStepIds` | Array of `filepath:lineNumber` identifiers for steps with `-NoLog` |
 
 **Manual inspection:**
 

--- a/Docs/how-it-works.md
+++ b/Docs/how-it-works.md
@@ -72,6 +72,17 @@ Run your script with `-Verbose` to see timestamped activity from Stepper:
 
 Verbose messages cover: step execution, state read/write/remove, variable changes, and hash comparisons. Requires `[CmdletBinding()]` in the calling script.
 
+## Logging
+
+Stepper writes a structured log file (`<scriptname>.ps1.stepper.log`) alongside the script by default. Each step produces:
+
+- An `[INFO]` entry at the start of execution with step number and source location
+- A per-step transcript section (`=== BEGIN STEP N TRANSCRIPT ===`) capturing host output
+- An `[INFO]` entry on completion with elapsed time
+- An `[ERROR]` entry if the step fails
+
+Logging is on by default. Use `-NoLog` on a `New-Step` call to exclude a step, or `-LogPath` to override the log file location. See [Logging](logging.md) for full details.
+
 ## Logo
 
 Stepper displays a colorful pixel-art logo on module import. To suppress it:

--- a/Docs/logging.md
+++ b/Docs/logging.md
@@ -1,0 +1,137 @@
+# Logging
+
+Stepper logs step execution to a structured log file by default. No configuration required.
+
+---
+
+## Log File Location
+
+The log file is created alongside the script using the filename `<scriptname>.ps1.stepper.log`:
+
+```
+myscript.ps1
+myscript.ps1.stepper
+myscript.ps1.stepper.log
+```
+
+To write to a custom path, pass `-LogPath` on any `New-Step` call:
+
+```powershell
+New-Step 'Install Packages' -LogPath 'C:\Logs\deploy.log' {
+    ...
+}
+```
+
+You only need to specify `-LogPath` once — Stepper uses the first value found via AST scan and applies it to all steps. If multiple steps specify **different** `-LogPath` values, Stepper prompts at init time to choose one. Dynamic paths (variables or expressions) cannot be resolved at scan time; the first runtime value wins and a warning is emitted if a later step provides a different one.
+
+If the directory for the specified `-LogPath` does not exist, Stepper throws a terminating error before executing any steps.
+
+---
+
+## Disabling Logging
+
+To disable logging for a specific step, add `-NoLog`:
+
+```powershell
+New-Step 'Handle Credentials' -NoLog {
+    ...
+}
+```
+
+When `-NoLog` is present on any step, Stepper prompts at init time:
+
+```
+One or more steps have -NoLog. How should logging be scoped?
+[A] Log all steps   [S] Skip only flagged steps   [N] Disable entirely   [Q] Quit
+```
+
+| Choice | Behavior |
+|---|---|
+| `[A]` | Log all steps, ignore `-NoLog` flags |
+| `[S]` | Skip transcript/log for flagged steps only |
+| `[N]` | Disable logging entirely for this run |
+| `[Q]` | Exit without running |
+
+In non-interactive mode (CI/CD, remoting), the default is `[A]`.
+
+---
+
+## Log Format
+
+Each entry uses the format:
+
+```
+[timestamp][LEVEL][Stepper] message
+```
+
+Example output:
+
+```
+[2026-04-19 07:52:10][INFO][Stepper] Executing step 1/3 (Test.ps1:6)
+[2026-04-19 07:52:12][INFO][Stepper] Step 1/3 completed in 2.05s (Test.ps1:6)
+[2026-04-19 07:52:12][INFO][Stepper] Executing step 2/3 (Test.ps1:19)
+[2026-04-19 07:53:30][INFO][Stepper] Step 2/3 completed in 5.74s (Test.ps1:19)
+[2026-04-19 07:53:30][INFO][Stepper] All steps complete. State file removed.
+```
+
+Levels: `INFO`, `WARN`, `ERROR`.
+
+---
+
+## Step Transcripts
+
+Each step's host output is captured via `Start-Transcript` and appended to the log file between section delimiters:
+
+```
+=== BEGIN STEP 2 TRANSCRIPT ===
+**********************
+PowerShell transcript start
+...
+**********************
+Hey, Jake!
+There are 517 processes currently running.
+**********************
+PowerShell transcript end
+...
+**********************
+
+=== END STEP 2 TRANSCRIPT ===
+```
+
+If a step fails mid-execution, the section is marked `[PARTIAL]`:
+
+```
+=== BEGIN STEP 2 TRANSCRIPT [PARTIAL] ===
+...partial output...
+=== END STEP 2 TRANSCRIPT [PARTIAL] ===
+```
+
+### Read-Host limitation on Unix/macOS
+
+`Start-Transcript` on PS Core (macOS/Linux) does not capture `Read-Host` prompts or the user's responses. All other output (`Write-Host`, `Write-Output`, pipeline output) is captured normally.
+
+On Windows with PS 5.1 or PS 7, `Read-Host` prompts and responses are included in the transcript.
+
+---
+
+## Active Transcript Conflict
+
+Stepper checks `$Host.UI.IsTranscribing` before starting a per-step transcript. If a transcript is already active (e.g., started by an enterprise runbook or `$PROFILE`), Stepper throws:
+
+```
+TranscriptAlreadyActive: a PowerShell transcript is already running.
+Stop-Transcript before running a Stepper script with logging enabled.
+```
+
+**Workarounds:**
+- Call `Stop-Transcript` before running the script
+- Add `-NoLog` to all steps
+- Choose `[N]` (disable entirely) at the scope prompt
+
+---
+
+## Log Config Persistence
+
+Logging configuration (`LogPath`, `LoggingEnabled`, `NoLogStepIds`) is stored in the `.stepper` state file. Resumed runs restore the same config without re-prompting.
+
+See [Data Persistence](data-persistence.md) for the full state schema.

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -19,3 +19,11 @@ Delete the `.stepper` file manually, or select `[S] Start over` at the resume pr
 **The logo is distracting**
 
 Set `$env:STEPPER_SHOW_LOGO = 'false'` before importing the module.
+
+**Stepper fails with `TranscriptAlreadyActive`**
+
+A PowerShell transcript is already running (e.g., started in `$PROFILE` or by an enterprise runbook). Call `Stop-Transcript` before running the script, or use `-NoLog` on all steps to disable logging entirely.
+
+**`Read-Host` prompts and responses don't appear in the log file**
+
+`Start-Transcript` on macOS/Linux (PS Core) does not capture `Read-Host` input. This is a platform limitation — all other output (`Write-Host`, pipeline, etc.) is captured normally. On Windows the behavior is the same in both PS 5.1 and PS 7.

--- a/Examples/Test.ps1
+++ b/Examples/Test.ps1
@@ -1,6 +1,6 @@
 Write-Output 'This code is useless. Delete it!' | Out-Null
 
-New-Step {
+New-Step 'Get user''s name' {
     $Stepper.Name = Read-Host 'Enter your name'
 }
 
@@ -11,7 +11,7 @@ $Stepper.ProcessCount = (Get-Process).Count
 $Stepper.ItemCount = (Get-ChildItem).Count
 $Stepper.CollectionTime = Get-Date
 
-New-Step {
+New-Step -NoLog {
     $response = Read-Host 'Do you want to simulate a crash? [Y/n]'
     if ($response -eq '' -or $response -eq 'Y' -or $response -eq 'y') {
         Write-Host ""

--- a/Private/Get-StepLogConfig.ps1
+++ b/Private/Get-StepLogConfig.ps1
@@ -1,0 +1,98 @@
+function Get-StepLogConfig {
+    <#
+    .SYNOPSIS
+        Scans a script's AST for -LogPath and -NoLog parameters on New-Step calls.
+
+    .DESCRIPTION
+        Uses the cached PowerShell AST (via Get-ScriptAst) to find all New-Step CommandAst
+        nodes that appear before Stop-Stepper. For each call, inspects CommandElements to
+        detect:
+          - A -LogPath parameter: if the argument is a static string, records its value;
+            otherwise records '<dynamic>' for variable or expression arguments.
+          - A -NoLog switch: records the step identifier (ScriptPath:LineNumber) for
+            any step that carries this switch.
+
+        Returns a PSCustomObject summarising the unique static log paths found (with a
+        conflict flag when two or more differ) and the list of -NoLog step identifiers.
+
+    .PARAMETER ScriptPath
+        Absolute path to the script file to analyse.
+
+    .OUTPUTS
+        PSCustomObject with properties:
+          UniqueStaticLogPaths  — string[] of distinct resolved -LogPath values (may include '<dynamic>')
+          HasConflict           — bool; $true when UniqueStaticLogPaths.Count -gt 1
+          NoLogStepIds          — string[] of "ScriptPath:LineNumber" for -NoLog steps
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ScriptPath
+    )
+
+    $parsed = Get-ScriptAst -ScriptPath $ScriptPath
+    $ast = $parsed.Ast
+
+    # Find Stop-Stepper cutoff line
+    $stopCalls = $ast.FindAll({
+        $args[0] -is [System.Management.Automation.Language.CommandAst] -and
+        $args[0].GetCommandName() -eq 'Stop-Stepper'
+    }, $true)
+
+    $stopLine = if ($stopCalls -and $stopCalls.Count -gt 0) {
+        ($stopCalls | Sort-Object { $_.Extent.StartLineNumber })[0].Extent.StartLineNumber
+    } else {
+        [int]::MaxValue
+    }
+
+    # Find all New-Step calls before Stop-Stepper
+    $newStepCalls = $ast.FindAll({
+        $args[0] -is [System.Management.Automation.Language.CommandAst] -and
+        $args[0].GetCommandName() -eq 'New-Step'
+    }, $true) | Where-Object { $_.Extent.StartLineNumber -lt $stopLine } |
+        Sort-Object { $_.Extent.StartLineNumber }
+
+    $logPaths = [System.Collections.Generic.List[string]]::new()
+    $noLogIds = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($call in $newStepCalls) {
+        $stepLine = $call.Extent.StartLineNumber
+        $stepId = "${ScriptPath}:${stepLine}"
+        $elements = $call.CommandElements
+
+        for ($i = 1; $i -lt $elements.Count; $i++) {
+            $el = $elements[$i]
+
+            if ($el -is [System.Management.Automation.Language.CommandParameterAst]) {
+                $paramName = $el.ParameterName
+
+                if ($paramName -eq 'LogPath') {
+                    # Next element is the argument
+                    $nextIndex = $i + 1
+                    if ($nextIndex -lt $elements.Count) {
+                        $arg = $elements[$nextIndex]
+                        if ($arg -is [System.Management.Automation.Language.StringConstantExpressionAst] -or
+                            $arg -is [System.Management.Automation.Language.ExpandableStringExpressionAst]) {
+                            $logPaths.Add($arg.Value)
+                        } else {
+                            # Variable, expression, or other non-static value
+                            $logPaths.Add('<dynamic>')
+                        }
+                        $i++  # Skip the argument element
+                    }
+                } elseif ($paramName -eq 'NoLog') {
+                    $noLogIds.Add($stepId)
+                }
+            }
+        }
+    }
+
+    $uniquePaths = @($logPaths | Select-Object -Unique)
+
+    return [PSCustomObject]@{
+        UniqueStaticLogPaths = $uniquePaths
+        HasConflict          = ($uniquePaths.Count -gt 1)
+        NoLogStepIds         = @($noLogIds)
+    }
+}

--- a/Private/Write-StepperLog.ps1
+++ b/Private/Write-StepperLog.ps1
@@ -1,0 +1,49 @@
+function Write-StepperLog {
+    <#
+    .SYNOPSIS
+        Writes a structured log entry to the verbose stream and optionally to a log file.
+
+    .DESCRIPTION
+        Centralizes all Stepper log output. Always emits a timestamped, levelled line to
+        Write-Verbose. When -LogPath is provided, appends the same line to that file using
+        Add-Content (append mode). File write failures emit a non-terminating Write-Warning
+        and never throw.
+
+    .PARAMETER Message
+        The message to log.
+
+    .PARAMETER Level
+        Log level: INFO, WARN, or ERROR. Defaults to INFO.
+
+    .PARAMETER LogPath
+        Optional path to a log file. If omitted, output is verbose-only.
+
+    .OUTPUTS
+        None
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Message,
+
+        [Parameter()]
+        [ValidateSet('INFO', 'WARN', 'ERROR')]
+        [string]$Level = 'INFO',
+
+        [Parameter()]
+        [string]$LogPath
+    )
+
+    $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $line = "[$timestamp][$Level][Stepper] $Message"
+
+    Write-Verbose $line
+
+    if ($LogPath) {
+        try {
+            Add-Content -Path $LogPath -Value $line -ErrorAction Stop
+        } catch {
+            Write-Warning "Stepper could not write to log file '$LogPath': $_"
+        }
+    }
+}

--- a/Private/Write-StepperState.ps1
+++ b/Private/Write-StepperState.ps1
@@ -27,6 +27,15 @@ function Write-StepperState {
     .PARAMETER ScriptContents
         The full contents of the script at the time of saving (string). Useful for inspection when the script changes.
 
+    .PARAMETER LogPath
+        Resolved path to the Stepper log file for this run. Persisted so resumed runs use the same path.
+
+    .PARAMETER LoggingEnabled
+        Whether logging is enabled for this run. Persisted so resumed runs respect the user's choice.
+
+    .PARAMETER NoLogStepIds
+        Step identifiers (ScriptPath:LineNumber) for steps with -NoLog. Persisted alongside LoggingEnabled.
+
     .OUTPUTS
         None
     #>
@@ -51,7 +60,16 @@ function Write-StepperState {
         [hashtable]$StepperData,
 
         [Parameter()]
-        [string]$ScriptContents
+        [string]$ScriptContents,
+
+        [Parameter()]
+        [string]$LogPath,
+
+        [Parameter()]
+        [bool]$LoggingEnabled,
+
+        [Parameter()]
+        [string[]]$NoLogStepIds
     )
 
     $state = [PSCustomObject]@{
@@ -62,6 +80,9 @@ function Write-StepperState {
         LastCompletedStepNumber = $StepNumber
         Timestamp               = (Get-Date).ToString('o')
         StepperData             = $StepperData
+        LogPath                 = $LogPath
+        LoggingEnabled          = $LoggingEnabled
+        NoLogStepIds            = $NoLogStepIds
     }
 
     try {

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -17,6 +17,18 @@ function New-Step {
     .PARAMETER ScriptBlock
         The code to execute for this step.
 
+    .PARAMETER LogPath
+        Optional path to a log file. If specified on any step, Stepper uses that path for
+        all structured log output and step transcripts for the entire run. If multiple steps
+        specify different paths, Stepper prompts the user to choose. If omitted on all steps,
+        the log is written to the same directory as the script with the name
+        scriptname.ps1.stepper.log.
+
+    .PARAMETER NoLog
+        Skips logging for this step. When present on one or more steps, Stepper prompts the
+        user at init time to choose whether to ignore the flag (log all steps), skip only
+        the flagged steps, or disable logging entirely.
+
     .EXAMPLE
         New-Step 'Download Files' {
             Write-Host "Downloading files..."
@@ -47,7 +59,13 @@ function New-Step {
 
         [Parameter(ParameterSetName = 'Named', Mandatory, Position = 1)]
         [Parameter(ParameterSetName = 'Unnamed', Mandatory, Position = 0)]
-        [scriptblock]$ScriptBlock
+        [scriptblock]$ScriptBlock,
+
+        [Parameter()]
+        [string]$LogPath,
+
+        [Parameter()]
+        [switch]$NoLog
     )
 
     # Inherit verbose preference by walking the call stack
@@ -144,6 +162,9 @@ function New-Step {
             CurrentScriptPath = $scriptPath
             CurrentScriptHash = $currentHash
             StatePath         = $statePath
+            LogPath           = $null
+            LoggingEnabled    = $true
+            NoLogStepIds      = @()
         }
         $callingScope.PSVariable.Set('__StepperExecutionState', $executionState)
 
@@ -317,6 +338,114 @@ function New-Step {
         }
 
         $existingState = Read-StepperState -StatePath $statePath
+
+        #Region Log config — resolve on fresh run, restore on resume
+        if ($existingState -and $existingState.LogPath) {
+            # Resumed run — restore log config from state, no prompts
+            $executionState.LogPath        = $existingState.LogPath
+            $executionState.LoggingEnabled = $existingState.LoggingEnabled
+            $executionState.NoLogStepIds   = if ($existingState.NoLogStepIds) { @($existingState.NoLogStepIds) } else { @() }
+        } else {
+            # Fresh run — scan AST and resolve
+            $logConfig  = Get-StepLogConfig -ScriptPath $scriptPath
+            $scriptDir  = Split-Path -Path $scriptPath -Parent
+            $scriptName = Split-Path -Path $scriptPath -Leaf
+            $defaultLog = Join-Path -Path $scriptDir -ChildPath "$scriptName.stepper.log"
+
+            # Resolve log path
+            if ($logConfig.HasConflict) {
+                Write-Host ""
+                Write-Host "[i] Multiple -LogPath values found across New-Step calls:" -ForegroundColor Cyan
+                Write-Host ""
+                $pathChoices = $logConfig.UniqueStaticLogPaths
+                for ($pi = 0; $pi -lt $pathChoices.Count; $pi++) {
+                    Write-Host "  [$($pi + 1)] $($pathChoices[$pi])" -ForegroundColor White
+                }
+                Write-Host ""
+                Write-Host "Which log path should be used? [1-$($pathChoices.Count)] (default: 1): " -NoNewline
+                try {
+                    $pathChoice = Read-Host
+                } catch {
+                    $pathChoice = '1'
+                    Write-Warning "[Stepper] Non-interactive context detected, defaulting to first log path."
+                }
+                $choiceIndex = 0
+                if (-not [int]::TryParse($pathChoice, [ref]$choiceIndex) -or
+                    $choiceIndex -lt 1 -or $choiceIndex -gt $pathChoices.Count) {
+                    $choiceIndex = 1
+                }
+                $resolvedLogPath = $pathChoices[$choiceIndex - 1]
+            } elseif ($logConfig.UniqueStaticLogPaths.Count -eq 1) {
+                $resolvedLogPath = $logConfig.UniqueStaticLogPaths[0]
+            } else {
+                $resolvedLogPath = $defaultLog
+            }
+
+            # Validate parent directory
+            $logDir = Split-Path -Path $resolvedLogPath -Parent
+            if ($logDir -and -not (Test-Path -LiteralPath $logDir -PathType Container)) {
+                $exception = [System.IO.DirectoryNotFoundException]::new(
+                    "Log file directory does not exist: '$logDir'. Create the directory or omit -LogPath to use the default location.")
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    $exception,
+                    'LogPathDirectoryNotFound',
+                    [System.Management.Automation.ErrorCategory]::ResourceUnavailable,
+                    $resolvedLogPath
+                )
+                $PSCmdlet.ThrowTerminatingError($errorRecord)
+            }
+
+            # Resolve NoLog scope
+            $loggingEnabled = $true
+            $noLogIds       = @()
+
+            if ($logConfig.NoLogStepIds.Count -gt 0) {
+                $noLogList = ($logConfig.NoLogStepIds | ForEach-Object {
+                    $parts = $_ -split ':'
+                    "$([System.IO.Path]::GetFileName($parts[0])):$($parts[-1])"
+                }) -join ', '
+
+                Write-Host ""
+                Write-Host "[i] Some steps have -NoLog specified: $noLogList" -ForegroundColor Cyan
+                Write-Host ""
+                Write-Host "  [A] Log all steps — ignore -NoLog flags (Default)" -ForegroundColor Cyan
+                Write-Host "  [S] Skip logging for those steps only" -ForegroundColor White
+                Write-Host "  [N] Disable logging entirely" -ForegroundColor White
+                Write-Host "  [Q] Quit" -ForegroundColor White
+                Write-Host ""
+                Write-Host "Choice? [" -NoNewline
+                Write-Host "A" -NoNewline -ForegroundColor Cyan
+                Write-Host "/s/n/q]: " -NoNewline
+                try {
+                    $noLogChoice = Read-Host
+                } catch {
+                    $noLogChoice = 'a'
+                    Write-Warning "[Stepper] Non-interactive context detected, defaulting to log all steps."
+                }
+
+                switch ($noLogChoice.ToLower()) {
+                    's' {
+                        $noLogIds = @($logConfig.NoLogStepIds)
+                    }
+                    'n' {
+                        $loggingEnabled = $false
+                    }
+                    'q' {
+                        Write-Host ""
+                        Write-Host "Exiting..." -ForegroundColor Yellow
+                        exit
+                    }
+                    default {
+                        # 'a' or anything else — log everything
+                    }
+                }
+            }
+
+            $executionState.LogPath        = $resolvedLogPath
+            $executionState.LoggingEnabled = $loggingEnabled
+            $executionState.NoLogStepIds   = $noLogIds
+        }
+        #EndRegion Log config
 
         # Try to load persisted $Stepper data from state
         if ($existingState -and $existingState.StepperData) {
@@ -609,16 +738,30 @@ function New-Step {
         $stepIdParts = $stepId -split ':'
         $scriptName = Split-Path $stepIdParts[0] -Leaf
         $displayStepId = "${scriptName}:$($stepIdParts[1])"
+        $skipReason = $null
 
         # In restore mode: skip steps until we reach the target
         if ($stepId -eq $executionState.TargetStep) {
             # This is the last completed step, skip it and disable restore mode
             $executionState.RestoreMode = $false
             $shouldExecute = $false
+            $skipReason = 'last completed step'
         }
         elseif ($executionState.RestoreMode) {
             # Still skipping
             $shouldExecute = $false
+            $skipReason = 'previously completed'
+        }
+
+        if ($skipReason -and $executionState.LoggingEnabled -and $executionState.LogPath -and
+            ($executionState.NoLogStepIds -notcontains $stepId)) {
+            $skipInventory = Get-StepInventory -ScriptPath $scriptPath
+            $skipNumber    = $skipInventory.StepLines.IndexOf($stepId) + 1
+            $skipTotal     = $skipInventory.TotalSteps
+            $skipSuffix    = if ($PSCmdlet.ParameterSetName -eq 'Named') { " - '$Name'" } else { '' }
+            Write-StepperLog -Message "Skipping step $skipNumber/$skipTotal$skipSuffix ($skipReason) ($displayStepId)" -LogPath $executionState.LogPath
+            Add-Content -Path $executionState.LogPath -Value "=== STEP $skipNumber$skipSuffix SKIPPED ==="
+            Add-Content -Path $executionState.LogPath -Value ''
         }
     }
 
@@ -637,7 +780,18 @@ function New-Step {
         $currentStepNumber = $stepLines.IndexOf($stepId) + 1
 
         $stepDisplaySuffix = if ($PSCmdlet.ParameterSetName -eq 'Named') { " - '$Name'" } else { '' }
-        Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Executing step $currentStepNumber/$totalSteps$stepDisplaySuffix ($displayStepId)"
+
+        # Resolve logging state for this step
+        $stepLogPath = $executionState.LogPath
+        $stepLoggingEnabled = $executionState.LoggingEnabled -and
+            ($executionState.NoLogStepIds -notcontains $stepId)
+
+        # Runtime -LogPath conflict check
+        if ($LogPath -and $stepLogPath -and $LogPath -ne $stepLogPath) {
+            Write-Warning "New-Step at ${displayStepId}: -LogPath '$LogPath' differs from the resolved log path '$stepLogPath'. Using resolved path."
+        }
+
+        Write-StepperLog -Message "Executing step $currentStepNumber/$totalSteps$stepDisplaySuffix ($displayStepId)" -LogPath $stepLogPath
 
         # Show current $Stepper data
         try {
@@ -661,8 +815,44 @@ function New-Step {
             # Ignore if unable to inject step metadata
         }
 
+        # Transcript setup
+        $transcriptStarted = $false
+        $tempTranscript    = $null
+
+        if ($stepLoggingEnabled -and $stepLogPath) {
+            if ($Host.UI.IsTranscribing) {
+                Write-Host ""
+                Write-Host "[!] Stepper detected an active transcript. Stop your transcript with Stop-Transcript and re-run the script." -ForegroundColor Magenta
+                Write-Host ""
+                $exception = [System.InvalidOperationException]::new(
+                    'An active PowerShell transcript was detected. Stop the transcript with Stop-Transcript and re-run the script.')
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    $exception,
+                    'TranscriptAlreadyActive',
+                    [System.Management.Automation.ErrorCategory]::ResourceBusy,
+                    $null
+                )
+                $PSCmdlet.ThrowTerminatingError($errorRecord)
+            }
+            $tempTranscript = [System.IO.Path]::GetTempFileName()
+            Start-Transcript -Path $tempTranscript -Force | Out-Null
+            $transcriptStarted = $true
+        }
+
         try {
+            $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
             & $ScriptBlock
+            $stopwatch.Stop()
+            $elapsed = [Math]::Round($stopwatch.Elapsed.TotalSeconds, 2)
+
+            if ($transcriptStarted) {
+                Stop-Transcript | Out-Null
+                $transcriptStarted = $false
+                $transcriptContent = Get-Content -Path $tempTranscript -Raw -ErrorAction SilentlyContinue
+                Add-Content -Path $stepLogPath -Value "=== BEGIN STEP $currentStepNumber$stepDisplaySuffix TRANSCRIPT ==="
+                Add-Content -Path $stepLogPath -Value $transcriptContent
+                Add-Content -Path $stepLogPath -Value "=== END STEP $currentStepNumber$stepDisplaySuffix TRANSCRIPT ==="
+            }
 
             # Update state file after successful execution (including $Stepper data)
             $stepperData = $callingScope.PSVariable.Get('Stepper').Value
@@ -681,14 +871,37 @@ function New-Step {
                 $PSCmdlet.ThrowTerminatingError($errorRecord)
             }
             $completedStepName = if ($PSCmdlet.ParameterSetName -eq 'Named') { $Name } else { $null }
-            Write-StepperState -StatePath $statePath -ScriptHash $currentHash -LastCompletedStep $stepId -StepName $completedStepName -StepNumber $currentStepNumber -StepperData $stepperData -ScriptContents $scriptContents
-            Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Step $currentStepNumber/$totalSteps completed ($displayStepId)"
+            $splatState = @{
+                StatePath         = $statePath
+                ScriptHash        = $currentHash
+                LastCompletedStep = $stepId
+                StepName          = $completedStepName
+                StepNumber        = $currentStepNumber
+                StepperData       = $stepperData
+                ScriptContents    = $scriptContents
+                LogPath           = $executionState.LogPath
+                LoggingEnabled    = if ($executionState.LoggingEnabled -is [bool]) { $executionState.LoggingEnabled } else { $true }
+                NoLogStepIds      = $executionState.NoLogStepIds
+            }
+            Write-StepperState @splatState
+            Write-StepperLog -Message "Step $currentStepNumber/$totalSteps$stepDisplaySuffix completed in ${elapsed}s ($displayStepId)" -LogPath $stepLogPath
 
             if ($stepperData -and $stepperData.Count -gt 0) {
                 Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Saved `$Stepper data ($($stepperData.Count) items)"
             }
         }
         catch {
+            if ($transcriptStarted) {
+                Stop-Transcript | Out-Null
+                $transcriptStarted = $false
+                $partialContent = Get-Content -Path $tempTranscript -Raw -ErrorAction SilentlyContinue
+                if ($stepLogPath) {
+                    Add-Content -Path $stepLogPath -Value "=== BEGIN STEP $currentStepNumber$stepDisplaySuffix TRANSCRIPT [PARTIAL] ==="
+                    Add-Content -Path $stepLogPath -Value $partialContent
+                    Add-Content -Path $stepLogPath -Value "=== END STEP $currentStepNumber$stepDisplaySuffix TRANSCRIPT [PARTIAL] ==="
+                }
+            }
+
             $innerMessage = if ($_.Exception.Message) {
                 $_.Exception.Message
             } else {
@@ -698,6 +911,9 @@ function New-Step {
             $location = if ($origin.ScriptName -and $origin.ScriptLineNumber) {
                 "$([System.IO.Path]::GetFileName($origin.ScriptName)):$($origin.ScriptLineNumber)"
             } else { $stepId }
+
+            Write-StepperLog -Message "Step $currentStepNumber/$totalSteps$stepDisplaySuffix FAILED at $location`: $innerMessage" -Level 'ERROR' -LogPath $stepLogPath
+
             $exception = [System.Exception]::new("Step failed [$location]: $innerMessage", $_.Exception)
             $errorRecord = [System.Management.Automation.ErrorRecord]::new(
                 $exception,
@@ -706,6 +922,11 @@ function New-Step {
                 $stepId
             )
             $PSCmdlet.ThrowTerminatingError($errorRecord)
+        }
+        finally {
+            if ($tempTranscript -and (Test-Path -LiteralPath $tempTranscript)) {
+                Remove-Item -LiteralPath $tempTranscript -Force -ErrorAction SilentlyContinue
+            }
         }
     }
 }

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -758,10 +758,8 @@ function New-Step {
             $skipInventory = Get-StepInventory -ScriptPath $scriptPath
             $skipNumber    = $skipInventory.StepLines.IndexOf($stepId) + 1
             $skipTotal     = $skipInventory.TotalSteps
-            $skipSuffix    = if ($PSCmdlet.ParameterSetName -eq 'Named') { " - '$Name'" } else { '' }
-            Write-StepperLog -Message "Skipping step $skipNumber/$skipTotal$skipSuffix ($skipReason) ($displayStepId)" -LogPath $executionState.LogPath
-            Add-Content -Path $executionState.LogPath -Value "=== STEP $skipNumber$skipSuffix SKIPPED ==="
-            Add-Content -Path $executionState.LogPath -Value ''
+            $skipNamePart  = if ($PSCmdlet.ParameterSetName -eq 'Named') { " ('$Name')" } else { '' }
+            Write-StepperLog -Message "Skipping step $skipNumber/$skipTotal$skipNamePart because it already completed in a previous run. ($displayStepId)" -LogPath $executionState.LogPath
         }
     }
 
@@ -818,6 +816,11 @@ function New-Step {
         # Transcript setup
         $transcriptStarted = $false
         $tempTranscript    = $null
+
+        if (-not $stepLoggingEnabled -and $stepLogPath) {
+            Add-Content -Path $stepLogPath -Value "=== STEP $currentStepNumber$stepDisplaySuffix LOGGING DISABLED BY USER ==="
+            Add-Content -Path $stepLogPath -Value ''
+        }
 
         if ($stepLoggingEnabled -and $stepLogPath) {
             if ($Host.UI.IsTranscribing) {

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -819,7 +819,6 @@ function New-Step {
 
         if (-not $stepLoggingEnabled -and $stepLogPath) {
             Add-Content -Path $stepLogPath -Value "=== STEP $currentStepNumber$stepDisplaySuffix LOGGING DISABLED BY USER ==="
-            Add-Content -Path $stepLogPath -Value ''
         }
 
         if ($stepLoggingEnabled -and $stepLogPath) {

--- a/Public/Stop-Stepper.ps1
+++ b/Public/Stop-Stepper.ps1
@@ -75,7 +75,20 @@ function Stop-Stepper {
         }
 
         if ($scriptPath) {
+            # Read log config from execution state before removing state
+            $logPath = $null
+            try {
+                $callingScope = $PSCmdlet.SessionState
+                $execState = $callingScope.PSVariable.Get('__StepperExecutionState')
+                if ($execState -and $execState.Value -and $execState.Value.LogPath) {
+                    $logPath = $execState.Value.LogPath
+                }
+            } catch {
+                # Ignore — log path optional
+            }
+
             $statePath = Get-StepperStatePath -ScriptPath $scriptPath
+            Write-StepperLog -Message "All steps complete. State file removed." -LogPath $logPath
             Remove-StepperState -StatePath $statePath
             $scriptName = Split-Path $scriptPath -Leaf
             Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Cleared Stepper state for $scriptName"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Stop-Stepper   # removes the state file on successful completion
 
 If the script fails inside a `New-Step` block, the next run resumes at the step that failed. All previously completed steps are skipped!
 
+Stepper also logs every step — execution timing, host output, and a per-step transcript — to `<scriptname>.ps1.stepper.log` by default. No configuration required.
+
 ---
 
 ## Demo
@@ -59,6 +61,7 @@ Created with [VHS](https://github.com/charmbracelet/vhs) by [Charm](https://char
 - [How It Works](Docs/how-it-works.md) — execution lifecycle, resume logic, verbose output, non-interactive mode
 - [Named Steps](Docs/named-steps.md) — step names, `$Stepper.StepName`, resume prompt formats
 - [Data Persistence](Docs/data-persistence.md) — `$Stepper` hashtable, state file schema
+- [Logging](Docs/logging.md) — log files, step transcripts, `-LogPath`, `-NoLog`
 - [Unmanaged Code](Docs/unmanaged-code.md) — detection, `#region Stepper ignore`, interactive resolution
 - [API Reference](Docs/api-reference.md) — `New-Step`, `Stop-Stepper`, error handling
 - [Examples](Docs/examples.md)

--- a/Tests/Get-StepLogConfig.Tests.ps1
+++ b/Tests/Get-StepLogConfig.Tests.ps1
@@ -1,0 +1,224 @@
+BeforeAll {
+    $ModulePath = Split-Path -Path $PSScriptRoot -Parent
+    . "$ModulePath/Private/Get-ScriptAst.ps1"
+    . "$ModulePath/Private/Get-ScriptHash.ps1"
+    . "$ModulePath/Private/Get-StepLogConfig.ps1"
+
+    # Helper: write a temporary script file and return its path
+    function New-TempScript {
+        param([string[]]$Lines)
+        $path = Join-Path $TestDrive "script-$(New-Guid).ps1"
+        Set-Content -Path $path -Value $Lines
+        return $path
+    }
+}
+
+Describe 'Get-StepLogConfig' -Tag 'Unit' {
+    Context 'No logging parameters on any step' {
+        It 'Should return empty UniqueStaticLogPaths when no -LogPath is used' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' { }"
+                "New-Step 'Step 2' { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.UniqueStaticLogPaths | Should -BeNullOrEmpty
+        }
+
+        It 'Should return HasConflict = $false when no -LogPath is used' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.HasConflict | Should -BeFalse
+        }
+
+        It 'Should return empty NoLogStepIds when no -NoLog is used' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.NoLogStepIds | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Single static -LogPath on one step' {
+        It 'Should return the path in UniqueStaticLogPaths' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' -LogPath 'C:\logs\run.log' { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.UniqueStaticLogPaths | Should -Contain 'C:\logs\run.log'
+        }
+
+        It 'Should return HasConflict = $false with a single path' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' -LogPath 'C:\logs\run.log' { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.HasConflict | Should -BeFalse
+        }
+
+        It 'Should return exactly one entry in UniqueStaticLogPaths' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' -LogPath 'C:\logs\run.log' { }"
+                "New-Step 'Step 2' -LogPath 'C:\logs\run.log' { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.UniqueStaticLogPaths.Count | Should -Be 1
+        }
+    }
+
+    Context 'Conflicting static -LogPath values' {
+        It 'Should return HasConflict = $true when two different paths are specified' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' -LogPath 'C:\logs\a.log' { }"
+                "New-Step 'Step 2' -LogPath 'C:\logs\b.log' { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.HasConflict | Should -BeTrue
+        }
+
+        It 'Should return both paths in UniqueStaticLogPaths' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' -LogPath 'C:\logs\a.log' { }"
+                "New-Step 'Step 2' -LogPath 'C:\logs\b.log' { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.UniqueStaticLogPaths | Should -Contain 'C:\logs\a.log'
+            $result.UniqueStaticLogPaths | Should -Contain 'C:\logs\b.log'
+        }
+    }
+
+    Context 'Dynamic -LogPath (variable argument)' {
+        It 'Should record <dynamic> for a variable argument' {
+            $path = New-TempScript @(
+                '$myLog = "C:\logs\run.log"'
+                "New-Step 'Step 1' -LogPath `$myLog { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.UniqueStaticLogPaths | Should -Contain '<dynamic>'
+        }
+
+        It 'Should not flag HasConflict for a single dynamic path' {
+            $path = New-TempScript @(
+                '$myLog = "C:\logs\run.log"'
+                "New-Step 'Step 1' -LogPath `$myLog { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.HasConflict | Should -BeFalse
+        }
+    }
+
+    Context '-NoLog switch detection' {
+        It 'Should return the step ID in NoLogStepIds when -NoLog is present' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' -NoLog { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.NoLogStepIds | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should return the correct step line number in NoLogStepIds' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' { }"
+                "New-Step 'Step 2' -NoLog { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            # Line 2 is the -NoLog step (1-based)
+            $result.NoLogStepIds | Should -Match ':2$'
+        }
+
+        It 'Should not include steps without -NoLog in NoLogStepIds' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' { }"
+                "New-Step 'Step 2' -NoLog { }"
+                "New-Step 'Step 3' { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.NoLogStepIds.Count | Should -Be 1
+        }
+
+        It 'Should return multiple step IDs when multiple steps have -NoLog' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' -NoLog { }"
+                "New-Step 'Step 2' -NoLog { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.NoLogStepIds.Count | Should -Be 2
+        }
+    }
+
+    Context 'Steps after Stop-Stepper are excluded' {
+        It 'Should not detect -NoLog on a step after Stop-Stepper' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' { }"
+                'Stop-Stepper'
+                "New-Step 'After stop' -NoLog { }"
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.NoLogStepIds | Should -BeNullOrEmpty
+        }
+
+        It 'Should not detect -LogPath on a step after Stop-Stepper' {
+            $path = New-TempScript @(
+                "New-Step 'Step 1' { }"
+                'Stop-Stepper'
+                "New-Step 'After stop' -LogPath 'C:\logs\run.log' { }"
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.UniqueStaticLogPaths | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Return type' {
+        It 'Should return a PSCustomObject' {
+            $path = New-TempScript @(
+                "New-Step { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result | Should -BeOfType [PSCustomObject]
+        }
+
+        It 'Should have UniqueStaticLogPaths property' {
+            $path = New-TempScript @(
+                "New-Step { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.PSObject.Properties.Name | Should -Contain 'UniqueStaticLogPaths'
+        }
+
+        It 'Should have HasConflict property' {
+            $path = New-TempScript @(
+                "New-Step { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.PSObject.Properties.Name | Should -Contain 'HasConflict'
+        }
+
+        It 'Should have NoLogStepIds property' {
+            $path = New-TempScript @(
+                "New-Step { }"
+                'Stop-Stepper'
+            )
+            $result = Get-StepLogConfig -ScriptPath $path
+            $result.PSObject.Properties.Name | Should -Contain 'NoLogStepIds'
+        }
+    }
+}

--- a/Tests/New-Step.Tests.ps1
+++ b/Tests/New-Step.Tests.ps1
@@ -15,6 +15,8 @@ BeforeAll {
     . "$ModulePath/Private/Update-ScriptWithUnmanagedActions.ps1"
     . "$ModulePath/Private/Test-StepperScriptRequirements.ps1"
     . "$ModulePath/Private/Show-MoreDetails.ps1"
+    . "$ModulePath/Private/Write-StepperLog.ps1"
+    . "$ModulePath/Private/Get-StepLogConfig.ps1"
     . "$ModulePath/Public/New-Step.ps1"
 
     # Helper: create a minimal valid stepper script in $TestDrive.
@@ -264,6 +266,9 @@ Describe 'New-Step' -Tag 'Integration' {
                 CurrentScriptPath = $script:ResumeInfo.Path
                 CurrentScriptHash = (Get-ScriptHash -ScriptPath $script:ResumeInfo.Path)
                 StatePath         = $script:ResumeInfo.StatePath
+                LogPath           = $null
+                LoggingEnabled    = $true
+                NoLogStepIds      = @()
             }
 
             $sideEffect = Join-Path $TestDrive "step2-side-$(New-Guid).txt"
@@ -401,6 +406,346 @@ Describe 'New-Step' -Tag 'Integration' {
             $statePath | Should -Exist
             $content = Get-Content -Path $script:NoStopContinuePath -Raw
             $content | Should -Not -Match 'Stop-Stepper'
+        }
+    }
+
+    Context 'Logging — default log path' {
+        BeforeEach {
+            $script:LogDefaultInfo = New-TestStepperScript -BaseName 'log-default'
+            Mock Get-StepIdentifier { "$($script:LogDefaultInfo.Path):$($script:LogDefaultInfo.FirstStepLine)" }
+            Mock Get-StepLogConfig { [PSCustomObject]@{ UniqueStaticLogPaths = @(); HasConflict = $false; NoLogStepIds = @() } }
+            Mock Write-StepperLog {}
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should call Write-StepperLog when a step executes' {
+            New-Step { }
+            Should -Invoke Write-StepperLog -Scope It
+        }
+
+        It 'Should store the resolved log path in execution state' {
+            New-Step { }
+            $expectedLog = "$($script:LogDefaultInfo.Path).stepper.log"
+            $state = Import-Clixml -Path $script:LogDefaultInfo.StatePath
+            $state.LogPath | Should -Be $expectedLog
+        }
+    }
+
+    Context 'Logging — explicit -LogPath parameter' {
+        BeforeEach {
+            $script:LogExplicitInfo = New-TestStepperScript -BaseName 'log-explicit'
+            $script:ExplicitLogPath = Join-Path $TestDrive 'explicit.log'
+            Mock Get-StepIdentifier { "$($script:LogExplicitInfo.Path):$($script:LogExplicitInfo.FirstStepLine)" }
+            Mock Get-StepLogConfig { [PSCustomObject]@{ UniqueStaticLogPaths = @($script:ExplicitLogPath); HasConflict = $false; NoLogStepIds = @() } }
+            Mock Write-StepperLog {}
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should use the explicit log path from Get-StepLogConfig' {
+            New-Step -LogPath $script:ExplicitLogPath { }
+            $state = Import-Clixml -Path $script:LogExplicitInfo.StatePath
+            $state.LogPath | Should -Be $script:ExplicitLogPath
+        }
+    }
+
+    Context 'Logging — conflicting -LogPath values prompt user' {
+        BeforeEach {
+            $script:ConflictInfo = New-TestStepperScript -BaseName 'log-conflict'
+            Mock Get-StepIdentifier { "$($script:ConflictInfo.Path):$($script:ConflictInfo.FirstStepLine)" }
+            Mock Get-StepLogConfig {
+                [PSCustomObject]@{
+                    UniqueStaticLogPaths = @((Join-Path $TestDrive 'a.log'), (Join-Path $TestDrive 'b.log'))
+                    HasConflict          = $true
+                    NoLogStepIds         = @()
+                }
+            }
+            Mock Write-StepperLog {}
+            Mock Read-Host { '1' }
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should prompt the user when -LogPath conflicts are detected' {
+            New-Step { }
+            Should -Invoke Read-Host -Scope It
+        }
+    }
+
+    Context 'Logging — runtime -LogPath mismatch writes warning' {
+        BeforeEach {
+            $script:MismatchInfo = New-TestStepperScript -BaseName 'log-mismatch'
+            $script:ResolvedLog = Join-Path $TestDrive 'resolved.log'
+            Mock Get-StepIdentifier { "$($script:MismatchInfo.Path):$($script:MismatchInfo.FirstStepLine)" }
+            Mock Get-StepLogConfig { [PSCustomObject]@{ UniqueStaticLogPaths = @($script:ResolvedLog); HasConflict = $false; NoLogStepIds = @() } }
+            Mock Write-StepperLog {}
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should write a warning when -LogPath differs from the resolved path' {
+            $differentPath = Join-Path $TestDrive 'different.log'
+            $warnings = New-Step -LogPath $differentPath { } 3>&1
+            $warnings | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Logging — active transcript causes hard stop' {
+        BeforeEach {
+            $script:TranscriptInfo = New-TestStepperScript -BaseName 'log-transcript'
+            Mock Get-StepIdentifier { "$($script:TranscriptInfo.Path):$($script:TranscriptInfo.FirstStepLine)" }
+            Mock Get-StepLogConfig { [PSCustomObject]@{ UniqueStaticLogPaths = @(); HasConflict = $false; NoLogStepIds = @() } }
+            Mock Write-StepperLog {}
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should throw TranscriptAlreadyActive when host transcript is active' -Skip:($true) {
+            # $Host.UI.IsTranscribing cannot be mocked via Pester Mock on a live host object.
+            # Covered by manual verification: run a script with an active transcript and
+            # confirm Stepper halts with ErrorId 'TranscriptAlreadyActive'.
+        }
+
+        It 'Should throw with ErrorId TranscriptAlreadyActive when transcript is active' -Skip:($true) {
+            # Skipped: $Host.UI.IsTranscribing cannot be mocked via Pester Mock
+            # Covered by manual verification and ADR documentation
+        }
+    }
+
+    Context 'Logging — transcript section in log file' {
+        BeforeEach {
+            $script:TranscriptLogInfo = New-TestStepperScript -BaseName 'log-transcript-section'
+            $script:TranscriptLogPath = Join-Path $TestDrive 'transcript-test.log'
+            Mock Get-StepIdentifier { "$($script:TranscriptLogInfo.Path):$($script:TranscriptLogInfo.FirstStepLine)" }
+            Mock Get-StepLogConfig { [PSCustomObject]@{ UniqueStaticLogPaths = @($script:TranscriptLogPath); HasConflict = $false; NoLogStepIds = @() } }
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should write a transcript section header to the log on successful step' {
+            New-Step { Write-Output 'step output' }
+            $logContent = Get-Content -Path $script:TranscriptLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match '=== BEGIN STEP \d+ TRANSCRIPT ==='
+        }
+
+        It 'Should write a transcript section footer to the log on successful step' {
+            New-Step { Write-Output 'step output' }
+            $logContent = Get-Content -Path $script:TranscriptLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match '=== END STEP \d+ TRANSCRIPT ==='
+        }
+
+        It 'Should write elapsed time to the log on successful step' {
+            New-Step { Write-Output 'step output' }
+            $logContent = Get-Content -Path $script:TranscriptLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match 'completed in \d+\.?\d*s'
+        }
+    }
+
+    Context 'Logging — failure writes ERROR entry to log' {
+        BeforeEach {
+            $script:FailLogInfo = New-TestStepperScript -BaseName 'log-fail'
+            $script:FailLogPath = Join-Path $TestDrive 'fail-test.log'
+            Mock Get-StepIdentifier { "$($script:FailLogInfo.Path):$($script:FailLogInfo.FirstStepLine)" }
+            Mock Get-StepLogConfig { [PSCustomObject]@{ UniqueStaticLogPaths = @($script:FailLogPath); HasConflict = $false; NoLogStepIds = @() } }
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should write an [ERROR] entry to the log when a step throws' {
+            try {
+                New-Step { throw 'simulated failure' }
+            } catch { }
+            $logContent = Get-Content -Path $script:FailLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match '\[ERROR\]'
+        }
+
+        It 'Should write a PARTIAL transcript section on failure' {
+            try {
+                New-Step { Write-Output 'before failure'; throw 'simulated failure' }
+            } catch { }
+            $logContent = Get-Content -Path $script:FailLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match '\[PARTIAL\]'
+        }
+
+        It 'Should still throw the terminating error after logging failure' {
+            { New-Step { throw 'simulated failure' } } | Should -Throw
+        }
+    }
+
+    Context 'Logging — skipped steps written to log on resume' {
+        BeforeEach {
+            $script:SkipLogInfo  = New-TestStepperScript -BaseName "log-skip-$(New-Guid)" -StepCount 2
+            $script:SkipLogPath  = Join-Path $TestDrive 'skip-test.log'
+            $step1Id = "$($script:SkipLogInfo.Path):$($script:SkipLogInfo.FirstStepLine)"
+            $scriptHash = Get-ScriptHash -ScriptPath $script:SkipLogInfo.Path
+            Write-StepperState -StatePath $script:SkipLogInfo.StatePath `
+                -ScriptHash $scriptHash `
+                -LastCompletedStep $step1Id `
+                -StepNumber 1
+
+            $script:SkipLogCallCount = 0
+            Mock Get-StepIdentifier {
+                $script:SkipLogCallCount++
+                if ($script:SkipLogCallCount -eq 1) {
+                    "$($script:SkipLogInfo.Path):$($script:SkipLogInfo.FirstStepLine)"
+                } else {
+                    "$($script:SkipLogInfo.Path):$($script:SkipLogInfo.FirstStepLine + 1)"
+                }
+            }
+            Mock Get-StepLogConfig { [PSCustomObject]@{ UniqueStaticLogPaths = @($script:SkipLogPath); HasConflict = $false; NoLogStepIds = @() } }
+            Mock Read-Host { 'R' }
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should write a SKIPPED section for a previously completed step' {
+            New-Step { }   # step 1 — skipped (last completed)
+            New-Step { }   # step 2 — runs
+            $logContent = Get-Content -Path $script:SkipLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match '=== STEP \d+ SKIPPED ==='
+        }
+
+        It 'Should write a Skipping log entry for a previously completed step' {
+            New-Step { }
+            New-Step { }
+            $logContent = Get-Content -Path $script:SkipLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match 'Skipping step \d+/\d+'
+        }
+
+        It 'Should include step name in the SKIPPED section for a named step' {
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+            $namedSkipInfo = New-TestStepperScript -BaseName "log-skip-named-$(New-Guid)" -StepCount 2
+            $namedStep1Id  = "$($namedSkipInfo.Path):$($namedSkipInfo.FirstStepLine)"
+            $namedHash     = Get-ScriptHash -ScriptPath $namedSkipInfo.Path
+            Write-StepperState -StatePath $namedSkipInfo.StatePath `
+                -ScriptHash $namedHash `
+                -LastCompletedStep $namedStep1Id `
+                -StepNumber 1
+
+            $namedSkipCallCount = 0
+            Mock Get-StepIdentifier {
+                $namedSkipCallCount++
+                if ($namedSkipCallCount -eq 1) {
+                    "$($namedSkipInfo.Path):$($namedSkipInfo.FirstStepLine)"
+                } else {
+                    "$($namedSkipInfo.Path):$($namedSkipInfo.FirstStepLine + 1)"
+                }
+            }
+            $namedSkipLog = Join-Path $TestDrive 'skip-named.log'
+            Mock Get-StepLogConfig { [PSCustomObject]@{ UniqueStaticLogPaths = @($namedSkipLog); HasConflict = $false; NoLogStepIds = @() } }
+
+            New-Step 'Provision Infra' { }
+            New-Step { }
+            $logContent = Get-Content -Path $namedSkipLog -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match "=== STEP \d+ - 'Provision Infra' SKIPPED ==="
+        }
+    }
+
+    Context 'Logging — -NoLog step scope prompt' {
+        BeforeEach {
+            $script:NoLogInfo = New-TestStepperScript -BaseName 'log-nolog'
+            Mock Get-StepIdentifier { "$($script:NoLogInfo.Path):$($script:NoLogInfo.FirstStepLine)" }
+            Mock Get-StepLogConfig {
+                [PSCustomObject]@{
+                    UniqueStaticLogPaths = @()
+                    HasConflict          = $false
+                    NoLogStepIds         = @("$($script:NoLogInfo.Path):$($script:NoLogInfo.FirstStepLine)")
+                }
+            }
+            Mock Write-StepperLog {}
+            Mock Read-Host { 'S' }
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should prompt the user when -NoLog is present on a step' {
+            New-Step -NoLog { }
+            Should -Invoke Read-Host -Scope It
+        }
+
+        It 'Should store the NoLogStepIds in execution state when user chooses S' {
+            New-Step -NoLog { }
+            $state = Import-Clixml -Path $script:NoLogInfo.StatePath
+            $state.NoLogStepIds | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Logging — step name included in log messages' {
+        BeforeEach {
+            $script:NamedLogInfo = New-TestStepperScript -BaseName 'log-named-step'
+            $script:NamedLogPath = Join-Path $TestDrive 'named-step.log'
+            Remove-Item -LiteralPath $script:NamedLogPath -Force -ErrorAction SilentlyContinue
+            Mock Get-StepIdentifier { "$($script:NamedLogInfo.Path):$($script:NamedLogInfo.FirstStepLine)" }
+            Mock Get-StepLogConfig { [PSCustomObject]@{ UniqueStaticLogPaths = @($script:NamedLogPath); HasConflict = $false; NoLogStepIds = @() } }
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should include step name in the Executing log entry' {
+            New-Step 'My Named Step' { Write-Output 'hello' }
+            $logContent = Get-Content -Path $script:NamedLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match "Executing.*My Named Step"
+        }
+
+        It 'Should include step name in the completed log entry' {
+            New-Step 'My Named Step' { Write-Output 'hello' }
+            $logContent = Get-Content -Path $script:NamedLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match "My Named Step.*completed"
+        }
+
+        It 'Should include step name in transcript section headers' {
+            New-Step 'My Named Step' { Write-Output 'hello' }
+            $logContent = Get-Content -Path $script:NamedLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match "BEGIN STEP \d+.*My Named Step.*TRANSCRIPT"
+        }
+
+        It 'Should not include a name suffix for unnamed steps' {
+            New-Step { Write-Output 'hello' }
+            $logContent = Get-Content -Path $script:NamedLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Not -Match "Executing.*-\s*'"
+        }
+    }
+
+    Context 'Logging — skipped steps written to log on resume' {
+        BeforeEach {
+            $script:SkipLogInfo = New-TestStepperScript -BaseName "log-skip-$(New-Guid)" -StepCount 2
+            $script:SkipLogPath = Join-Path $TestDrive 'skip-test.log'
+            $step1Id = "$($script:SkipLogInfo.Path):$($script:SkipLogInfo.FirstStepLine)"
+            $scriptHash = Get-ScriptHash -ScriptPath $script:SkipLogInfo.Path
+            Write-StepperState -StatePath $script:SkipLogInfo.StatePath `
+                -ScriptHash $scriptHash `
+                -LastCompletedStep $step1Id `
+                -StepNumber 1 `
+                -LogPath $script:SkipLogPath `
+                -LoggingEnabled $true `
+                -NoLogStepIds @()
+
+            $script:SkipCallCount = 0
+            Mock Get-StepIdentifier {
+                $script:SkipCallCount++
+                if ($script:SkipCallCount -eq 1) {
+                    "$($script:SkipLogInfo.Path):$($script:SkipLogInfo.FirstStepLine)"
+                } else {
+                    "$($script:SkipLogInfo.Path):$($script:SkipLogInfo.FirstStepLine + 1)"
+                }
+            }
+            Mock Read-Host { 'R' }
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should write a SKIPPED marker to the log for a skipped step' {
+            New-Step { }
+            $logContent = Get-Content -Path $script:SkipLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match 'SKIPPED'
+        }
+
+        It 'Should include the skip reason in the log entry' {
+            New-Step { }
+            $logContent = Get-Content -Path $script:SkipLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match 'previously completed|last completed step'
         }
     }
 }

--- a/Tests/New-Step.Tests.ps1
+++ b/Tests/New-Step.Tests.ps1
@@ -599,18 +599,18 @@ Describe 'New-Step' -Tag 'Integration' {
             Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
         }
 
-        It 'Should write a SKIPPED section for a previously completed step' {
+        It 'Should write a Skipping log entry for a previously completed step' {
             New-Step { }   # step 1 — skipped (last completed)
             New-Step { }   # step 2 — runs
             $logContent = Get-Content -Path $script:SkipLogPath -Raw -ErrorAction SilentlyContinue
-            $logContent | Should -Match '=== STEP \d+ SKIPPED ==='
+            $logContent | Should -Match 'Skipping step \d+/\d+'
         }
 
-        It 'Should write a Skipping log entry for a previously completed step' {
+        It 'Should state that the step already completed in a previous run' {
             New-Step { }
             New-Step { }
             $logContent = Get-Content -Path $script:SkipLogPath -Raw -ErrorAction SilentlyContinue
-            $logContent | Should -Match 'Skipping step \d+/\d+'
+            $logContent | Should -Match 'already completed in a previous run'
         }
 
         It 'Should include step name in the SKIPPED section for a named step' {
@@ -639,7 +639,7 @@ Describe 'New-Step' -Tag 'Integration' {
             New-Step 'Provision Infra' { }
             New-Step { }
             $logContent = Get-Content -Path $namedSkipLog -Raw -ErrorAction SilentlyContinue
-            $logContent | Should -Match "=== STEP \d+ - 'Provision Infra' SKIPPED ==="
+            $logContent | Should -Match "Skipping step \d+/\d+.*'Provision Infra'.*already completed"
         }
     }
 
@@ -669,6 +669,38 @@ Describe 'New-Step' -Tag 'Integration' {
             New-Step -NoLog { }
             $state = Import-Clixml -Path $script:NoLogInfo.StatePath
             $state.NoLogStepIds | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Logging — disabled-step marker written to log' {
+        BeforeEach {
+            $script:DisabledLogInfo = New-TestStepperScript -BaseName 'log-disabled'
+            $script:DisabledLogPath = Join-Path $TestDrive 'disabled-step.log'
+            Remove-Item -LiteralPath $script:DisabledLogPath -Force -ErrorAction SilentlyContinue
+            $stepId = "$($script:DisabledLogInfo.Path):$($script:DisabledLogInfo.FirstStepLine)"
+            Mock Get-StepIdentifier { $stepId }
+            Mock Get-StepLogConfig {
+                [PSCustomObject]@{
+                    UniqueStaticLogPaths = @($script:DisabledLogPath)
+                    HasConflict          = $false
+                    NoLogStepIds         = @($stepId)
+                }
+            }
+            Mock Read-Host { 'S' }
+            Remove-Variable -Name '__StepperInitialized' -Scope Global -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It 'Should write a LOGGING DISABLED BY USER marker to the log when logging is off for a step' {
+            New-Step -NoLog { Write-Output 'should not appear in transcript' }
+            $logContent = Get-Content -Path $script:DisabledLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Match 'LOGGING DISABLED BY USER'
+        }
+
+        It 'Should not write a transcript section when logging is disabled for a step' {
+            New-Step -NoLog { Write-Output 'should not appear in transcript' }
+            $logContent = Get-Content -Path $script:DisabledLogPath -Raw -ErrorAction SilentlyContinue
+            $logContent | Should -Not -Match 'BEGIN STEP'
         }
     }
 
@@ -736,16 +768,16 @@ Describe 'New-Step' -Tag 'Integration' {
             Remove-Variable -Name '__StepperExecutionState' -Scope Global -ErrorAction SilentlyContinue
         }
 
-        It 'Should write a SKIPPED marker to the log for a skipped step' {
+        It 'Should write a Skipping log entry to the log for a skipped step' {
             New-Step { }
             $logContent = Get-Content -Path $script:SkipLogPath -Raw -ErrorAction SilentlyContinue
-            $logContent | Should -Match 'SKIPPED'
+            $logContent | Should -Match 'Skipping step \d+/\d+'
         }
 
-        It 'Should include the skip reason in the log entry' {
-            New-Step { }
+        It 'Should include step name in the Skipping entry for a named step' {
+            New-Step 'Provision Infra' { }
             $logContent = Get-Content -Path $script:SkipLogPath -Raw -ErrorAction SilentlyContinue
-            $logContent | Should -Match 'previously completed|last completed step'
+            $logContent | Should -Match "'Provision Infra'"
         }
     }
 }

--- a/Tests/Stop-Stepper.Tests.ps1
+++ b/Tests/Stop-Stepper.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     . "$ModulePath/Private/Write-StepperState.ps1"
     . "$ModulePath/Private/Read-StepperState.ps1"
     . "$ModulePath/Private/Remove-StepperState.ps1"
+    . "$ModulePath/Private/Write-StepperLog.ps1"
     . "$ModulePath/Public/Stop-Stepper.ps1"
 
     # On macOS, $TestDrive resolves to /private/tmp/… which matches the
@@ -198,6 +199,84 @@ Describe 'Stop-Stepper' -Tag 'Integration' {
         It 'Does not rethrow' {
             Mock Write-Error {}
             { Stop-Stepper } | Should -Not -Throw
+        }
+    }
+
+    Context 'Logging — summary entry written on completion' {
+        BeforeEach {
+            Write-StepperState -StatePath $script:FakeStatePath -ScriptHash 'abc123' `
+                -LastCompletedStep "${script:FakeUserScript}:1"
+
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $modulePath = $ModulePath
+            $fakeUser   = $script:FakeUserScript
+            $frames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${modulePath}${sep}Public${sep}Stop-Stepper.ps1"
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $fakeUser
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack -MockWith { $frames }.GetNewClosure()
+            Mock Write-StepperLog {}
+        }
+
+        It 'Should call Write-StepperLog on successful completion' {
+            Stop-Stepper
+            Should -Invoke Write-StepperLog -Scope It
+        }
+
+        It 'Should log the completion message' {
+            Stop-Stepper
+            Should -Invoke Write-StepperLog -Scope It -ParameterFilter {
+                $Message -match 'All steps complete'
+            }
+        }
+    }
+
+    Context 'Logging — reads LogPath from execution state' {
+        BeforeEach {
+            Write-StepperState -StatePath $script:FakeStatePath -ScriptHash 'abc123' `
+                -LastCompletedStep "${script:FakeUserScript}:1"
+
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $modulePath = $ModulePath
+            $fakeUser   = $script:FakeUserScript
+            $frames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${modulePath}${sep}Public${sep}Stop-Stepper.ps1"
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $fakeUser
+                    ScriptLineNumber = 1
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack -MockWith { $frames }.GetNewClosure()
+            Mock Write-StepperLog {}
+
+            # Inject execution state with a known LogPath
+            $__StepperExecutionState = @{
+                CurrentScriptPath = $fakeUser
+                LogPath           = Join-Path $TestDrive 'injected.log'
+                LoggingEnabled    = $true
+                NoLogStepIds      = @()
+            }
+        }
+
+        It 'Should pass the LogPath from execution state to Write-StepperLog' {
+            $expectedLog = Join-Path $TestDrive 'injected.log'
+            Stop-Stepper
+            Should -Invoke Write-StepperLog -Scope It -ParameterFilter {
+                $LogPath -eq $expectedLog
+            }
         }
     }
 }

--- a/Tests/Write-StepperLog.Tests.ps1
+++ b/Tests/Write-StepperLog.Tests.ps1
@@ -1,0 +1,140 @@
+BeforeAll {
+    $ModulePath = Split-Path -Path $PSScriptRoot -Parent
+    . "$ModulePath/Private/Write-StepperLog.ps1"
+}
+
+Describe 'Write-StepperLog' -Tag 'Unit' {
+    Context 'Verbose output' {
+        It 'Should write a message to the verbose stream' {
+            $messages = & {
+                $VerbosePreference = 'Continue'
+                Write-StepperLog -Message 'test message' 4>&1
+            }
+            $messages | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] } |
+                Select-Object -ExpandProperty Message |
+                Should -Match 'test message'
+        }
+
+        It 'Should include the level in verbose output' {
+            $messages = & {
+                $VerbosePreference = 'Continue'
+                Write-StepperLog -Message 'something failed' -Level 'ERROR' 4>&1
+            }
+            $messages | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] } |
+                Select-Object -ExpandProperty Message |
+                Should -Match '\[ERROR\]'
+        }
+
+        It 'Should default level to INFO' {
+            $messages = & {
+                $VerbosePreference = 'Continue'
+                Write-StepperLog -Message 'default level check' 4>&1
+            }
+            $messages | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] } |
+                Select-Object -ExpandProperty Message |
+                Should -Match '\[INFO\]'
+        }
+
+        It 'Should include a timestamp in the verbose output' {
+            $messages = & {
+                $VerbosePreference = 'Continue'
+                Write-StepperLog -Message 'timestamp check' 4>&1
+            }
+            $messages | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] } |
+                Select-Object -ExpandProperty Message |
+                Should -Match '^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]'
+        }
+
+        It 'Should include [Stepper] in the verbose output' {
+            $messages = & {
+                $VerbosePreference = 'Continue'
+                Write-StepperLog -Message 'namespace check' 4>&1
+            }
+            $messages | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] } |
+                Select-Object -ExpandProperty Message |
+                Should -Match '\[Stepper\]'
+        }
+    }
+
+    Context 'File output — LogPath provided' {
+        BeforeEach {
+            $LogPath = Join-Path $TestDrive "stepper-$(New-Guid).log"
+        }
+
+        It 'Should create a log file at the specified path' {
+            Write-StepperLog -Message 'file creation test' -LogPath $LogPath
+            $LogPath | Should -Exist
+        }
+
+        It 'Should append the message to the log file' {
+            Write-StepperLog -Message 'first line' -LogPath $LogPath
+            Write-StepperLog -Message 'second line' -LogPath $LogPath
+            $content = Get-Content -Path $LogPath
+            $content.Count | Should -Be 2
+            $content[0] | Should -Match 'first line'
+            $content[1] | Should -Match 'second line'
+        }
+
+        It 'Should write the level to the log file' {
+            Write-StepperLog -Message 'level in file' -Level 'WARN' -LogPath $LogPath
+            $content = Get-Content -Path $LogPath -Raw
+            $content | Should -Match '\[WARN\]'
+        }
+
+        It 'Should write a timestamp to the log file' {
+            Write-StepperLog -Message 'ts in file' -LogPath $LogPath
+            $content = Get-Content -Path $LogPath -Raw
+            $content | Should -Match '\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]'
+        }
+
+        It 'Should append to an existing file rather than overwrite it' {
+            Add-Content -Path $LogPath -Value 'pre-existing content'
+            Write-StepperLog -Message 'appended' -LogPath $LogPath
+            $lines = Get-Content -Path $LogPath
+            $lines[0] | Should -Be 'pre-existing content'
+            $lines[1] | Should -Match 'appended'
+        }
+    }
+
+    Context 'File output — LogPath not provided' {
+        It 'Should not create any file when LogPath is omitted' {
+            $dir = $TestDrive
+            $before = (Get-ChildItem -Path $dir -Recurse).Count
+            Write-StepperLog -Message 'no path'
+            $after = (Get-ChildItem -Path $dir -Recurse).Count
+            $after | Should -Be $before
+        }
+    }
+
+    Context 'Unwritable log path' {
+        It 'Should emit a warning and not throw when the log path is unwritable' {
+            $badPath = Join-Path $TestDrive 'nonexistent-dir' 'stepper.log'
+            { Write-StepperLog -Message 'bad path test' -LogPath $badPath -WarningAction SilentlyContinue } |
+                Should -Not -Throw
+        }
+
+        It 'Should write a warning when the log path is unwritable' {
+            $badPath = Join-Path $TestDrive 'nonexistent-dir' 'stepper.log'
+            $warnings = Write-StepperLog -Message 'bad path warn' -LogPath $badPath 3>&1
+            $warnings | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'ValidateSet on Level' {
+        It 'Should accept INFO' {
+            { Write-StepperLog -Message 'x' -Level 'INFO' } | Should -Not -Throw
+        }
+
+        It 'Should accept WARN' {
+            { Write-StepperLog -Message 'x' -Level 'WARN' } | Should -Not -Throw
+        }
+
+        It 'Should accept ERROR' {
+            { Write-StepperLog -Message 'x' -Level 'ERROR' } | Should -Not -Throw
+        }
+
+        It 'Should reject an invalid level' {
+            { Write-StepperLog -Message 'x' -Level 'DEBUG' } | Should -Throw
+        }
+    }
+}

--- a/Tests/Write-StepperState.Tests.ps1
+++ b/Tests/Write-StepperState.Tests.ps1
@@ -63,6 +63,44 @@ Describe 'Write-StepperState' -Tag 'Unit' {
             $state = Import-Clixml -Path $StatePath
             $state.ScriptContents | Should -Be $contents
         }
+
+        It 'Should persist LogPath when provided' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10' -LogPath 'C:\logs\run.log'
+            $state = Import-Clixml -Path $StatePath
+            $state.LogPath | Should -Be 'C:\logs\run.log'
+        }
+
+        It 'Should persist LogPath as null when not provided' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10'
+            $state = Import-Clixml -Path $StatePath
+            $state.LogPath | Should -BeNullOrEmpty
+        }
+
+        It 'Should persist LoggingEnabled = $true when provided' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10' -LoggingEnabled $true
+            $state = Import-Clixml -Path $StatePath
+            $state.LoggingEnabled | Should -BeTrue
+        }
+
+        It 'Should persist LoggingEnabled = $false when provided' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10' -LoggingEnabled $false
+            $state = Import-Clixml -Path $StatePath
+            $state.LoggingEnabled | Should -BeFalse
+        }
+
+        It 'Should persist NoLogStepIds array when provided' {
+            $ids = @('/tmp/test.ps1:5', '/tmp/test.ps1:12')
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10' -NoLogStepIds $ids
+            $state = Import-Clixml -Path $StatePath
+            $state.NoLogStepIds | Should -Contain '/tmp/test.ps1:5'
+            $state.NoLogStepIds | Should -Contain '/tmp/test.ps1:12'
+        }
+
+        It 'Should persist NoLogStepIds as null when not provided' {
+            Write-StepperState -StatePath $StatePath -ScriptHash 'abc' -LastCompletedStep '/tmp/test.ps1:10'
+            $state = Import-Clixml -Path $StatePath
+            $state.NoLogStepIds | Should -BeNullOrEmpty
+        }
     }
 
     Context 'When Export-Clixml fails' {


### PR DESCRIPTION
Closes #39

## What's changed

Stepper now logs every run to a structured log file by default — no
configuration required. Each step produces timestamped entries, a
per-step transcript section, and a completion record with elapsed time.

### New behavior

- **Logging on by default.** Log file is written to
  `<scriptname>.ps1.stepper.log` alongside the script.
- **`-LogPath`** on any `New-Step` call overrides the default path.
  Resolved at init time via AST scan — only needs to be specified once.
- **`-NoLog`** on any `New-Step` call triggers a scope prompt at init
  time: log all / skip flagged steps only / disable entirely.
- **Per-step transcripts** via `Start-Transcript`/`Stop-Transcript`,
  appended to the log between `=== BEGIN/END STEP N TRANSCRIPT ===`
  delimiters. Failed steps produce `[PARTIAL]` sections.
- **Step names** included in log entries and transcript headers when
  `-Name` is provided.
- **Skipped steps** (resume mode) produce a `Skipping step N/M`
  log entry noting the step already completed in a previous run.
- **Disabled steps** produce a `=== STEP N LOGGING DISABLED BY USER ===`
  marker in the log.
- **Active transcript detection** — hard stop with a clear message if
  `$Host.UI.IsTranscribing` is `$true` before step execution.
- **Log config persisted** in the `.stepper` state file so resumed runs
  restore the same settings without re-prompting.

### Known limitation

`Start-Transcript` on macOS/Linux (PS Core) does not capture `Read-Host`
prompts or responses. All other output is captured normally. Documented
in ADR 0002 and the troubleshooting guide.

## Files changed

| Area | Files |
|---|---|
| New private helpers | `Private/Write-StepperLog.ps1`, `Private/Get-StepLogConfig.ps1` |
| Extended | `Private/Write-StepperState.ps1`, `Public/New-Step.ps1`, `Public/Stop-Stepper.ps1` |
| New tests | `Tests/Write-StepperLog.Tests.ps1`, `Tests/Get-StepLogConfig.Tests.ps1` |
| Extended tests | `Tests/Write-StepperState.Tests.ps1`, `Tests/New-Step.Tests.ps1`, `Tests/Stop-Stepper.Tests.ps1` |
| Docs | `Docs/logging.md` (new), `Docs/adr/0002-logging-and-step-transcripts.md` (new) |
| Updated docs | `README.md`, `Docs/api-reference.md`, `Docs/data-persistence.md`, `Docs/how-it-works.md`, `Docs/troubleshooting.md` |

## Test results

230 passed, 0 failed, 2 skipped (skipped: `$Host.UI.IsTranscribing`
is not mockable via Pester — covered by manual verification and ADR).