### PR TITLE
feature: Harden script requirements check: independent CmdletBinding + install guard injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Lib/Core/*
 
 # Stepper state files
 *.stepper
+*.stepper.log
 
 # Beads / Dolt files (added by bd init)
 .dolt/

--- a/Docs/how-it-works.md
+++ b/Docs/how-it-works.md
@@ -4,7 +4,7 @@
 
 Before executing any steps, Stepper validates the script:
 
-1. Checks for `[CmdletBinding()]` — if missing, silently injects `[CmdletBinding()]`, `param()`, and a self-install guard, then exits and asks you to re-run. No prompt, no `#Requires` statement added.
+1. Checks for `[CmdletBinding()]` and the self-install guard independently — each is silently injected if missing. The guard is wrapped in `#region Stepper ignore` so it won't trigger unmanaged-code warnings on the next run. No prompt, no `#Requires` statement added.
 2. Scans for unmanaged code between `New-Step` blocks — prompts per block: Wrap / Mark / Delete / Ignore
 3. Checks that `Stop-Stepper` appears at the end
 

--- a/Private/Test-StepperScriptRequirements.ps1
+++ b/Private/Test-StepperScriptRequirements.ps1
@@ -1,10 +1,13 @@
 function Test-StepperScriptRequirements {
     <#
     .SYNOPSIS
-        Checks if a script has a [CmdletBinding()] declaration and silently adds it if missing.
+        Checks if a script has [CmdletBinding()] and the Stepper self-install guard, and silently adds either if missing.
 
     .PARAMETER ScriptPath
         Path to the script to check.
+
+    .PARAMETER LogPath
+        Path to the Stepper log file. Defaults to ScriptPath + '.stepper.log'.
 
     .OUTPUTS
         $true if the script was modified and needs to be re-run, $false otherwise.
@@ -12,8 +15,15 @@ function Test-StepperScriptRequirements {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$ScriptPath
+        [string]$ScriptPath,
+
+        [Parameter()]
+        [string]$LogPath
     )
+
+    if (-not $LogPath) {
+        $LogPath = $ScriptPath + '.stepper.log'
+    }
 
     try {
         $scriptLines = Get-Content -Path $ScriptPath -ErrorAction Stop
@@ -38,12 +48,13 @@ function Test-StepperScriptRequirements {
         ($parsedAst.Ast.ParamBlock.Attributes |
             Where-Object { $_.TypeName.Name -eq 'CmdletBinding' })
 
-    $needsChanges = -not $hasCmdletBinding
+    $hasInstallGuard = $scriptLines | Where-Object { $_ -match 'Install-Module\s+Stepper' }
+    $needsChanges = -not $hasCmdletBinding -or -not $hasInstallGuard
 
     if ($needsChanges) {
         $newScriptLines = @()
-        $addedDeclarations = $false
 
+        if (-not $hasCmdletBinding) {
             # Find where to insert (after shebang/comments at top, before first code)
             $insertIndex = 0
             for ($i = 0; $i -lt $scriptLines.Count; $i++) {
@@ -61,23 +72,22 @@ function Test-StepperScriptRequirements {
                 $newScriptLines += $scriptLines[$i]
             }
 
-            # Add missing [CmdletBinding()]
+            # Add missing [CmdletBinding()] and guard (only inject guard if not already present)
             $newScriptLines += "[CmdletBinding()]"
             $newScriptLines += "param()"
-            $newScriptLines += "if (-not (Get-Module -Name Stepper) -and -not (Get-Module -ListAvailable -Name Stepper)) { Install-Module Stepper -Force }"
-            $addedDeclarations = $true
-            Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Added missing '[CmdletBinding()]' and Stepper install guard to $scriptName"
-
-            if ($addedDeclarations) {
-                $newScriptLines += ""
+            if (-not $hasInstallGuard) {
+                $newScriptLines += "#region Stepper ignore"
+                $newScriptLines += "if (-not (Get-Module -Name Stepper) -and -not (Get-Module -ListAvailable -Name Stepper)) { Install-Module Stepper -Force }"
+                $newScriptLines += "#endregion Stepper ignore"
             }
+            $newScriptLines += ""
+            Write-StepperLog -Message "Added missing '[CmdletBinding()]' and Stepper install guard to $scriptName" -LogPath $LogPath
 
             # Copy remaining lines, skipping the existing empty param() block if we added one.
             # Use AST extent to handle both single-line and multi-line empty param blocks.
             $existingParamStart = -1
             $existingParamEnd   = -1
-            if (-not $hasCmdletBinding -and
-                $parsedAst.Ast.ParamBlock -and
+            if ($parsedAst.Ast.ParamBlock -and
                 $parsedAst.Ast.ParamBlock.Parameters.Count -eq 0) {
                 $existingParamStart = $parsedAst.Ast.ParamBlock.Extent.StartLineNumber - 1
                 $existingParamEnd   = $parsedAst.Ast.ParamBlock.Extent.EndLineNumber - 1
@@ -90,35 +100,56 @@ function Test-StepperScriptRequirements {
                 }
                 $newScriptLines += $scriptLines[$i]
             }
-
-            # Write back to file
-            try {
-                $newScriptLines | Set-Content -Path $ScriptPath -Force -ErrorAction Stop
-            }
-            catch {
-                $exception = [System.IO.IOException]::new("Failed to write to script file '$ScriptPath'", $_.Exception)
-                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
-                    $exception,
-                    'ScriptWriteFailed',
-                    [System.Management.Automation.ErrorCategory]::WriteError,
-                    $ScriptPath
-                )
-                $PSCmdlet.ThrowTerminatingError($errorRecord)
+        } else {
+            # [CmdletBinding()] exists but guard is missing — insert guard after param() block
+            $guardInsertIndex = if ($parsedAst.Ast.ParamBlock) {
+                $parsedAst.Ast.ParamBlock.Extent.EndLineNumber
+            } else {
+                ($scriptLines | Select-String '\[CmdletBinding' | Select-Object -First 1).LineNumber
             }
 
-            # Delete state file since script was modified
-            $statePath = Get-StepperStatePath -ScriptPath $ScriptPath
-            Remove-StepperState -StatePath $statePath
+            for ($i = 0; $i -lt $guardInsertIndex; $i++) {
+                $newScriptLines += $scriptLines[$i]
+            }
+            $newScriptLines += "#region Stepper ignore"
+            $newScriptLines += "if (-not (Get-Module -Name Stepper) -and -not (Get-Module -ListAvailable -Name Stepper)) { Install-Module Stepper -Force }"
+            $newScriptLines += "#endregion Stepper ignore"
+            for ($i = $guardInsertIndex; $i -lt $scriptLines.Count; $i++) {
+                $newScriptLines += $scriptLines[$i]
+            }
+            Write-StepperLog -Message "Added missing Stepper install guard to $scriptName" -LogPath $LogPath
+        }
 
-            Write-Host ""
-            Write-Host "[+] Stepper updated $scriptName with required declarations:" -ForegroundColor Cyan
+        # Write back to file
+        try {
+            $newScriptLines | Set-Content -Path $ScriptPath -Force -ErrorAction Stop
+        }
+        catch {
+            $exception = [System.IO.IOException]::new("Failed to write to script file '$ScriptPath'", $_.Exception)
+            $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                $exception,
+                'ScriptWriteFailed',
+                [System.Management.Automation.ErrorCategory]::WriteError,
+                $ScriptPath
+            )
+            $PSCmdlet.ThrowTerminatingError($errorRecord)
+        }
+
+        # Delete state file since script was modified
+        $statePath = Get-StepperStatePath -ScriptPath $ScriptPath
+        Remove-StepperState -StatePath $statePath
+
+        Write-Host ""
+        Write-Host "[+] Stepper updated $scriptName with required declarations:" -ForegroundColor Cyan
+        if (-not $hasCmdletBinding) {
             Write-Host "      Added: [CmdletBinding()] param()" -ForegroundColor Gray
-            Write-Host "      Added: Install-Module Stepper guard (runs only if not installed)" -ForegroundColor Gray
-            Write-Host ""
-            Write-Host "[>] Please re-run your script to continue." -ForegroundColor Yellow
-            Write-Host ""
+        }
+        Write-Host "      Added: Install-Module Stepper guard (runs only if not installed)" -ForegroundColor Gray
+        Write-Host ""
+        Write-Host "[>] Please re-run your script to continue." -ForegroundColor Yellow
+        Write-Host ""
 
-            return $true
+        return $true
     }
 
     return $false

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Stop-Stepper   # removes the state file on successful completion
 
 If the script fails inside a `New-Step` block, the next run resumes at the step that failed. All previously completed steps are skipped!
 
-On first run, Stepper checks for `[CmdletBinding()]` — if it's missing, it silently injects `[CmdletBinding()]`, `param()`, and a self-install guard, then exits and asks you to re-run. Nothing is required beyond what's shown above.
+On first run, Stepper checks for `[CmdletBinding()]` and the self-install guard independently — each is silently injected if missing (the guard is wrapped in `#region Stepper ignore` so it won't trigger unmanaged-code warnings), then Stepper exits and asks you to re-run. Nothing is required beyond what's shown above.
 
 Stepper also logs every step — execution timing, host output, and a per-step transcript — to `<scriptname>.ps1.stepper.log` by default. No configuration required.
 

--- a/Tests/Test-StepperScriptRequirements.Tests.ps1
+++ b/Tests/Test-StepperScriptRequirements.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     . "$ModulePath/Private/Get-ScriptAst.ps1"
     . "$ModulePath/Private/Get-StepperStatePath.ps1"
     . "$ModulePath/Private/Remove-StepperState.ps1"
+    . "$ModulePath/Private/Write-StepperLog.ps1"
     . "$ModulePath/Private/Test-StepperScriptRequirements.ps1"
 }
 
@@ -12,14 +13,18 @@ Describe 'Test-StepperScriptRequirements' -Tag 'Unit' {
         Mock Write-Host {}
         Mock Read-Host {}
         Mock Write-Verbose {}
+        Mock Write-StepperLog {}
     }
 
-    Context 'When script already has [CmdletBinding()]' {
+    Context 'When script already has [CmdletBinding()] and Install-Module guard' {
         BeforeEach {
             $script:ScriptPath = Join-Path $TestDrive "complete-$(New-Guid).ps1"
             Set-Content -Path $script:ScriptPath -Value @(
                 '[CmdletBinding()]'
                 'param()'
+                '#region Stepper ignore'
+                'if (-not (Get-Module -Name Stepper) -and -not (Get-Module -ListAvailable -Name Stepper)) { Install-Module Stepper -Force }'
+                '#endregion Stepper ignore'
                 'New-Step { Write-Host "step" }'
                 'Stop-Stepper'
             )
@@ -35,9 +40,74 @@ Describe 'Test-StepperScriptRequirements' -Tag 'Unit' {
             Should -Invoke Read-Host -Exactly 0 -Scope It
         }
 
-        It 'Should not emit verbose about adding declarations' {
+        It 'Should not call Write-StepperLog about adding declarations' {
             Test-StepperScriptRequirements -ScriptPath $script:ScriptPath
-            Should -Invoke Write-Verbose -Exactly 0 -Scope It -ParameterFilter { $Message -match 'Added missing' }
+            Should -Invoke Write-StepperLog -Exactly 0 -Scope It
+        }
+    }
+
+    Context 'When [CmdletBinding()] exists but Install-Module guard is missing' {
+        BeforeEach {
+            $script:MissingGuardPath = Join-Path $TestDrive "missing-guard-$(New-Guid).ps1"
+            Set-Content -Path $script:MissingGuardPath -Value @(
+                '[CmdletBinding()]'
+                'param()'
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+        }
+
+        It 'Should return $true' {
+            $result = Test-StepperScriptRequirements -ScriptPath $script:MissingGuardPath
+            $result | Should -BeTrue
+        }
+
+        It 'Should add the Install-Module guard' {
+            Test-StepperScriptRequirements -ScriptPath $script:MissingGuardPath
+            $content = Get-Content -Path $script:MissingGuardPath -Raw
+            $content | Should -Match 'Install-Module Stepper'
+        }
+
+        It 'Should wrap the guard in a Stepper ignore region' {
+            Test-StepperScriptRequirements -ScriptPath $script:MissingGuardPath
+            $content = Get-Content -Path $script:MissingGuardPath -Raw
+            $content | Should -Match '#region Stepper ignore'
+        }
+
+        It 'Should not add a second [CmdletBinding()]' {
+            Test-StepperScriptRequirements -ScriptPath $script:MissingGuardPath
+            $lines = Get-Content -Path $script:MissingGuardPath
+            ($lines | Where-Object { $_ -match '\[CmdletBinding\(\)\]' }).Count | Should -Be 1
+        }
+
+        It 'Should not add a second param()' {
+            Test-StepperScriptRequirements -ScriptPath $script:MissingGuardPath
+            $lines = Get-Content -Path $script:MissingGuardPath
+            ($lines | Where-Object { $_ -match '^\s*param\s*\(' }).Count | Should -Be 1
+        }
+
+        It 'Should insert guard after param() block' {
+            Test-StepperScriptRequirements -ScriptPath $script:MissingGuardPath
+            $lines = Get-Content -Path $script:MissingGuardPath
+            $paramIdx = [array]::IndexOf($lines, 'param()')
+            $guardIdx = ($lines | Select-String 'Install-Module Stepper').LineNumber - 1
+            $guardIdx | Should -BeGreaterThan $paramIdx
+        }
+
+        It 'Should call Write-StepperLog reporting the addition' {
+            Test-StepperScriptRequirements -ScriptPath $script:MissingGuardPath
+            Should -Invoke Write-StepperLog -Scope It
+        }
+
+        It 'Should write to the default log file' {
+            $expectedLog = $script:MissingGuardPath + '.stepper.log'
+            Test-StepperScriptRequirements -ScriptPath $script:MissingGuardPath
+            Should -Invoke Write-StepperLog -Scope It -ParameterFilter { $LogPath -eq $expectedLog }
+        }
+
+        It 'Should not call Read-Host' {
+            Test-StepperScriptRequirements -ScriptPath $script:MissingGuardPath
+            Should -Invoke Read-Host -Exactly 0 -Scope It
         }
     }
 
@@ -68,14 +138,51 @@ Describe 'Test-StepperScriptRequirements' -Tag 'Unit' {
             $content | Should -Match 'Install-Module Stepper'
         }
 
-        It 'Should emit Write-Verbose reporting the addition' {
+        It 'Should call Write-StepperLog reporting the addition' {
             Test-StepperScriptRequirements -ScriptPath $script:CbMissingPath
-            Should -Invoke Write-Verbose -Scope It
+            Should -Invoke Write-StepperLog -Scope It
+        }
+
+        It 'Should write to the default log file' {
+            $expectedLog = $script:CbMissingPath + '.stepper.log'
+            Test-StepperScriptRequirements -ScriptPath $script:CbMissingPath
+            Should -Invoke Write-StepperLog -Scope It -ParameterFilter { $LogPath -eq $expectedLog }
         }
 
         It 'Should not call Read-Host' {
             Test-StepperScriptRequirements -ScriptPath $script:CbMissingPath
             Should -Invoke Read-Host -Exactly 0 -Scope It
+        }
+    }
+
+    Context 'When [CmdletBinding()] is missing but Install-Module guard already exists' {
+        BeforeEach {
+            $script:GuardOnlyPath = Join-Path $TestDrive "guard-only-$(New-Guid).ps1"
+            Set-Content -Path $script:GuardOnlyPath -Value @(
+                'param()'
+                '#region Stepper ignore'
+                'if (-not (Get-Module -Name Stepper) -and -not (Get-Module -ListAvailable -Name Stepper)) { Install-Module Stepper -Force }'
+                '#endregion Stepper ignore'
+                'New-Step { Write-Host "step" }'
+                'Stop-Stepper'
+            )
+        }
+
+        It 'Should return $true' {
+            $result = Test-StepperScriptRequirements -ScriptPath $script:GuardOnlyPath
+            $result | Should -BeTrue
+        }
+
+        It 'Should add [CmdletBinding()]' {
+            Test-StepperScriptRequirements -ScriptPath $script:GuardOnlyPath
+            $content = Get-Content -Path $script:GuardOnlyPath -Raw
+            $content | Should -Match '\[CmdletBinding\(\)\]'
+        }
+
+        It 'Should not duplicate the Install-Module guard' {
+            Test-StepperScriptRequirements -ScriptPath $script:GuardOnlyPath
+            $lines = Get-Content -Path $script:GuardOnlyPath
+            ($lines | Where-Object { $_ -match 'Install-Module Stepper' }).Count | Should -Be 1
         }
     }
 
@@ -85,6 +192,9 @@ Describe 'Test-StepperScriptRequirements' -Tag 'Unit' {
             Set-Content -Path $scriptPath -Value @(
                 '[CmdletBinding()]'
                 'param()'
+                '#region Stepper ignore'
+                'if (-not (Get-Module -Name Stepper) -and -not (Get-Module -ListAvailable -Name Stepper)) { Install-Module Stepper -Force }'
+                '#endregion Stepper ignore'
                 'New-Step { Write-Host "step" }'
                 'Stop-Stepper'
             )
@@ -125,9 +235,15 @@ Describe 'Test-StepperScriptRequirements' -Tag 'Unit' {
             $content | Should -Not -Match '(?i)#requires'
         }
 
-        It 'Should emit Write-Verbose reporting the addition' {
+        It 'Should call Write-StepperLog reporting the addition' {
             Test-StepperScriptRequirements -ScriptPath $script:MissingBothPath
-            Should -Invoke Write-Verbose -Scope It
+            Should -Invoke Write-StepperLog -Scope It
+        }
+
+        It 'Should write to the default log file' {
+            $expectedLog = $script:MissingBothPath + '.stepper.log'
+            Test-StepperScriptRequirements -ScriptPath $script:MissingBothPath
+            Should -Invoke Write-StepperLog -Scope It -ParameterFilter { $LogPath -eq $expectedLog }
         }
 
         It 'Should not call Read-Host' {
@@ -177,6 +293,9 @@ Describe 'Test-StepperScriptRequirements' -Tag 'Unit' {
             Set-Content -Path $scriptPath -Value @(
                 '[CmdletBinding()]'
                 'param()'
+                '#region Stepper ignore'
+                'if (-not (Get-Module -Name Stepper) -and -not (Get-Module -ListAvailable -Name Stepper)) { Install-Module Stepper -Force }'
+                '#endregion Stepper ignore'
                 'New-Step { Write-Host "step" }'
                 'Stop-Stepper'
             )


### PR DESCRIPTION
## Summary

`Test-StepperScriptRequirements` previously treated `[CmdletBinding()]` and the
`Install-Module Stepper` guard as a single unit — either both were there or both got
injected. This meant a user who manually deleted just the guard (or who had already
written their own `[CmdletBinding()]`) would silently miss it.

This PR fixes that by checking each requirement independently and injecting only what's
missing.

## Changes

**`Private/Test-StepperScriptRequirements.ps1`**
- `[CmdletBinding()]` and `Install-Module Stepper` guard are now checked and injected
  independently — all 4 presence/absence combinations handled correctly
- Injected guard is wrapped in `#region Stepper ignore` to prevent it from triggering
  unmanaged-code warnings on the next run
- Replaced `Write-Verbose` with `Write-StepperLog` so script modifications are recorded
  in the log file, not just the verbose stream
- Added optional `-LogPath` parameter (defaults to `<scriptname>.ps1.stepper.log`)

**`Tests/Test-StepperScriptRequirements.Tests.ps1`**
- Added `Write-StepperLog` to BeforeAll imports and mocks
- New contexts: guard-missing-only, CmdletBinding-missing-only (guard already present),
  guard-present-but-CmdletBinding-missing (no duplication)
- Log path assertions on all modification paths
- Fixture scripts updated to include the guard where appropriate

**`README.md` / `Docs/how-it-works.md`**
- Updated wording to reflect independent checks and `#region Stepper ignore` behavior

**`.gitignore`**
- Added `*.stepper.log`

## Tests
290 passed, 0 failed