### PR TITLE
fix(ci): fix GHA Stop-Stepper test failures caused by ErrorActionPreference

### DIFF
--- a/Tests/Stop-Stepper.Tests.ps1
+++ b/Tests/Stop-Stepper.Tests.ps1
@@ -191,6 +191,9 @@ Describe 'Stop-Stepper' -Tag 'Integration' {
         }
 
         It 'Writes a non-terminating error' {
+            # GHA sets $ErrorActionPreference = 'Stop' globally; override here so
+            # $PSCmdlet.WriteError() writes to the error stream instead of throwing
+            $ErrorActionPreference = 'Continue'
             $result = Stop-Stepper 2>&1
             $errRecords = @($result | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] })
             $errRecords.Count | Should -Be 1
@@ -198,6 +201,7 @@ Describe 'Stop-Stepper' -Tag 'Integration' {
         }
 
         It 'Does not rethrow' {
+            $ErrorActionPreference = 'Continue'
             { Stop-Stepper 2>&1 | Out-Null } | Should -Not -Throw
         }
     }


### PR DESCRIPTION
## Problem

Two `Stop-Stepper` tests were failing in GitHub Actions:

- `Writes a non-terminating error`
- `Does not rethrow`

Root cause: GHA's `pwsh` shell steps set `$ErrorActionPreference = 'Stop'` by default. `$PSCmdlet.WriteError()` respects `$ErrorActionPreference`, so under `Stop` it becomes terminating — causing the `2>&1` stream capture to throw instead of capturing the error record.

## Fix

Set `$ErrorActionPreference = 'Continue'` at the top of each affected `It` block. This overrides the GHA environment setting for that test's scope without modifying the function under test or passing `-ErrorAction` to `Stop-Stepper` (which would change the behavior being tested).

## Why not use `-ErrorAction Continue` on the function call?

That would modify the system under test to make the test pass — a test smell. The correct approach per Pester best practices is to control the test environment, not the function under test.

## Tests

`Stop-Stepper.Tests.ps1`: 10/10 passing locally and expected green in GHA.