### PR TITLE
docs(phase-7): document ConvertTo-StepperScript, retry behavior, and fix dialog option casing

### DIFF
--- a/Docs/adr/0001-ast-parsing-over-regex.md
+++ b/Docs/adr/0001-ast-parsing-over-regex.md
@@ -14,7 +14,7 @@ Three categories of fragility were identified:
 
 1. **Structural detection:** `New-Step` regex requires `{` on the same line as the call, breaking if the scriptblock is on the next line. Manual brace-counting to find block end does not account for `{`/`}` inside strings or heredocs.
 2. **Comment span detection:** `<#` / `#>` are matched line-by-line, which breaks if either token appears after executable code on the same line.
-3. **Executable-line classification:** A 5-pattern regex whitelist (`[CmdletBinding(`, `param(`, `using`, etc.) is used to skip "non-executable" lines. Incomplete by construction — any pattern not in the list is a false positive.
+3. **Executable-line classification:** A 5-pattern regex whitelist (`[CmdletBinding(`, `param(`, `using`, etc.) is used to skip "non-executable" lines. Incomplete by construction; any pattern not in the list is a false positive.
 
 Additionally, the step-counting + name-listing logic is copy-pasted verbatim 3 times in `New-Step.ps1` (lines 349–371, 501–529, 713–740), and the script file is read from disk 2–3 times per `New-Step` execution.
 
@@ -27,7 +27,7 @@ Replace all structural regex with `[System.Management.Automation.Language.Parser
 Introduce a new private function `Get-ScriptAst` that:
 - Calls `[Parser]::ParseFile()`, returning `[PSCustomObject]@{ Ast; Tokens; Errors }`
 - Emits `Write-Warning` per parse error and returns the partial AST (callers decide whether to abort)
-- Maintains a module-scoped `$script:astCache` hashtable keyed on `"$ScriptPath:$hash"` (using the existing `Get-ScriptHash` function) — auto-invalidates when the script changes, eliminates redundant disk reads
+- Maintains a module-scoped `$script:astCache` hashtable keyed on `"$ScriptPath:$hash"` (using the existing `Get-ScriptHash` function); auto-invalidates when the script changes, eliminates redundant disk reads
 
 ---
 
@@ -39,14 +39,14 @@ The PowerShell AST is syntax-aware. It correctly handles:
 - `New-Step` and `Stop-Stepper` appearing inside comments (they simply won't produce `CommandAst` nodes)
 - All PS quoting rules by construction
 
-The alternative — keeping regex but fixing edge cases — is a local patch on a structural problem. Every edge case fixed reveals the next one.
+The alternative (keeping regex but fixing edge cases) is a local patch on a structural problem. Every edge case fixed reveals the next one.
 
 ---
 
 ## Consequences
 
 - `Get-ScriptAst.ps1` added to `Private/`
-- `Get-StepInventory.ps1` added to `Private/` — encapsulates the deduplicated step-counting logic
+- `Get-StepInventory.ps1` added to `Private/`: encapsulates the deduplicated step-counting logic
 - `Find-NewStepBlocks.ps1` signature changes from `[object[]]$ScriptLines` to `[string]$ScriptPath`; brace-counting loop replaced with `$ast.FindAll(...)` + `Extent` properties
 - `Find-UnmanagedCodeBlocks.ps1` comment detection replaced with token stream inspection; executable-line classification replaced with AST extent check
 - `Test-StepperScriptRequirements.ps1` uses `$ast.ParamBlock.Attributes` and `$ast.ScriptRequirements.RequiredModules` instead of regex
@@ -58,6 +58,6 @@ The alternative — keeping regex but fixing edge cases — is a local patch on 
 
 ## Rejected alternative
 
-**Direct `[Parser]::ParseFile()` calls per function** — each function would handle its own `[ref]` vars and error handling. Rejected because:
+**Direct `[Parser]::ParseFile()` calls per function**: each function would handle its own `[ref]` vars and error handling. Rejected because:
 - Error handling (`Write-Warning` per parse error) would be copy-pasted into 4–5 functions and drift over time
-- The re-parsing problem (2–3 disk reads per execution) stays unfixed — caching can only be centralized in a wrapper
+- The re-parsing problem (2–3 disk reads per execution) stays unfixed; caching can only be centralized in a wrapper

--- a/Docs/adr/0002-logging-and-step-transcripts.md
+++ b/Docs/adr/0002-logging-and-step-transcripts.md
@@ -8,7 +8,7 @@
 
 ## Context
 
-Stepper had no persistent log output. All status information was emitted via `Write-Verbose`, which is ephemeral — lost if the caller omits `-Verbose` or does not capture output. There was no record of step runtimes, step failures, or what happened during a previous run.
+Stepper had no persistent log output. All status information was emitted via `Write-Verbose`, which is ephemeral; lost if the caller omits `-Verbose` or does not capture output. There was no record of step runtimes, step failures, or what happened during a previous run.
 
 Three design questions required explicit decisions before implementation:
 
@@ -24,13 +24,13 @@ Three design questions required explicit decisions before implementation:
 
 Logging is enabled for every step unless the user explicitly passes `-NoLog` to a `New-Step` call. When `-NoLog` is present on any step, Stepper prompts the user at init time to choose scope:
 
-- **A** — log all steps (ignore `-NoLog` flags)
-- **S** — skip logging for the flagged steps only
-- **D** — disable logging entirely
+- **A**, log all steps (ignore `-NoLog` flags)
+- **S**, skip logging for the flagged steps only
+- **D**, disable logging entirely
 
 This decision is persisted in the `.stepper` state file so resumed runs do not re-prompt.
 
-Rationale: unattended scripts need logs most — requiring an explicit opt-in means logs are missing exactly when they're most needed.
+Rationale: unattended scripts need logs most; requiring an explicit opt-in means logs are missing exactly when they're most needed.
 
 ### Native `Start-Transcript` per step, folded into the log file
 
@@ -42,7 +42,7 @@ Rationale: `Start-Transcript` captures the full host output including `Write-Hos
 
 Before starting a per-step transcript, Stepper checks `$Host.UI.IsTranscribing`. If `$true`, it emits a clear user-facing message and throws a terminating error (`TranscriptAlreadyActive`, category `ResourceBusy`). It does not silently skip transcript capture and continue.
 
-Rationale: silently skipping produces a log with missing transcript sections — worse than a clear failure because the user may not notice. A hard stop with an actionable message (`Stop-Transcript and re-run`) is unambiguous.
+Rationale: silently skipping produces a log with missing transcript sections; worse than a clear failure because the user may not notice. A hard stop with an actionable message (`Stop-Transcript and re-run`) is unambiguous.
 
 ### Default log path: `scriptname.ps1.stepper.log` alongside the script
 
@@ -54,19 +54,19 @@ If one or more `New-Step` calls specify `-LogPath` with a static string, that pa
 
 `LogPath`, `LoggingEnabled`, and `NoLogStepIds` are added to the existing `Export-Clixml` state object. On a resumed run, these values are read from state and applied without re-prompting.
 
-Rationale: consistency — the path and scope decisions made on the first run should apply to the resumed run, which may be unattended.
+Rationale: consistency; the path and scope decisions made on the first run should apply to the resumed run, which may be unattended.
 
 ---
 
 ## Consequences
 
 - **New private functions:** `Write-StepperLog` (structured log helper), `Get-StepLogConfig` (AST scan for `-LogPath` and `-NoLog` across all steps)
-- **State schema change:** three new fields (`LogPath`, `LoggingEnabled`, `NoLogStepIds`) added to the `Export-Clixml` object in `Write-StepperState.ps1`. Backwards compatible — old state files simply lack these fields (treated as `$null`/`$false`).
+- **State schema change:** three new fields (`LogPath`, `LoggingEnabled`, `NoLogStepIds`) added to the `Export-Clixml` object in `Write-StepperState.ps1`. Backwards compatible; old state files simply lack these fields (treated as `$null`/`$false`).
 - **`New-Step` new params:** `-LogPath [string]`, `-NoLog [switch]`
 - **`Stop-Stepper` no new params:** reads `LogPath` from `__StepperExecutionState` in the calling scope; no user-facing change.
-- **Temp files:** one temp file per step execution, deleted in a `finally` block. If the process is killed mid-step, the temp file may be orphaned in `$env:TEMP` — acceptable.
+- **Temp files:** one temp file per step execution, deleted in a `finally` block. If the process is killed mid-step, the temp file may be orphaned in `$env:TEMP`; acceptable.
 - **PS 5.1 + active transcript:** hard stop with `TranscriptAlreadyActive`. Users running enterprise runbooks that pre-start transcripts must stop them before using Stepper logging. `-NoLog` on all steps or `-N` at the scope prompt is the workaround.
-- **`Read-Host` not captured in transcripts on Unix/macOS:** `Start-Transcript` on PS Core (Unix/macOS) does not capture `Read-Host` prompts or their responses. Pipeline output, `Write-Host`, and `Write-Output` are captured normally. This is a `Start-Transcript` platform limitation — not a Stepper defect. On Windows (PS 5.1 or PS 7), `Read-Host` prompts are captured.
+- **`Read-Host` not captured in transcripts on Unix/macOS:** `Start-Transcript` on PS Core (Unix/macOS) does not capture `Read-Host` prompts or their responses. Pipeline output, `Write-Host`, and `Write-Output` are captured normally. This is a `Start-Transcript` platform limitation; not a Stepper defect. On Windows (PS 5.1 or PS 7), `Read-Host` prompts are captured.
 
 ---
 

--- a/Docs/adr/0003-silent-auto-add-requirements.md
+++ b/Docs/adr/0003-silent-auto-add-requirements.md
@@ -12,10 +12,10 @@
 
 This behavior is problematic:
 
-1. **Blocks automation** — any CI/CD pipeline or unattended run hangs indefinitely waiting for interactive input.
-2. **Surprises users** — an unexpected halt mid-execution on first run violates the principle of least surprise.
-3. **Violates module design principles** — `Read-Host` is explicitly against Stepper's non-interactive design pattern.
-4. **"Skip" is a footgun** — silently continuing without the required declarations causes unpredictable failures downstream, making it the worst option despite being the easiest to reach.
+1. **Blocks automation**: any CI/CD pipeline or unattended run hangs indefinitely waiting for interactive input.
+2. **Surprises users**: an unexpected halt mid-execution on first run violates the principle of least surprise.
+3. **Violates module design principles**: `Read-Host` is explicitly against Stepper's non-interactive design pattern.
+4. **"Skip" is a footgun**: silently continuing without the required declarations causes unpredictable failures downstream, making it the worst option despite being the easiest to reach.
 
 The only safe response in the old dialog was always "Add". The "Skip" and "Quit" paths offer false choice.
 
@@ -27,14 +27,14 @@ Replace the interactive prompt with silent auto-add behavior:
 
 - If declarations are missing, add them and return `$true` without any user prompt.
 - Emit one `Write-Verbose` call per declaration added.
-- Delete any existing state file (same as before — the script has structurally changed).
+- Delete any existing state file (same as before; the script has structurally changed).
 - Add a `-SkipRequirementsCheck` `[switch]` parameter to `New-Step` for callers who want to bypass the check entirely.
 
 ---
 
 ## Rationale
 
-Silent auto-add preserves the original intent (ensure the script is properly structured) while eliminating interactive friction. Since "Add" was the only safe option in the old prompt, auto-add is semantically equivalent to the old default. `Write-Verbose` satisfies observability without blocking execution — users running with `-Verbose` see exactly what changed.
+Silent auto-add preserves the original intent (ensure the script is properly structured) while eliminating interactive friction. Since "Add" was the only safe option in the old prompt, auto-add is semantically equivalent to the old default. `Write-Verbose` satisfies observability without blocking execution; users running with `-Verbose` see exactly what changed.
 
 The `-SkipRequirementsCheck` escape hatch gives advanced users who consciously manage their own declarations a clean opt-out, without requiring workarounds or file hacks.
 

--- a/Docs/adr/0004-convert-steppersscript-output-target.md
+++ b/Docs/adr/0004-convert-steppersscript-output-target.md
@@ -11,8 +11,8 @@
 `Convert-StepperScript` rewrites variable references inside `New-Step` blocks from `$var` to `$Stepper.Var`. A rewrite tool that modifies files needs a clear answer to "where does the output go?"
 
 Two options were considered:
-1. **In-place only** — always overwrites the source file
-2. **In-place with backup + optional -OutputPath** — default is in-place with a `.bak` copy; `-OutputPath` writes to a new file instead, leaving the original untouched
+1. **In-place only**: always overwrites the source file
+2. **In-place with backup + optional -OutputPath**: default is in-place with a `.bak` copy; `-OutputPath` writes to a new file instead, leaving the original untouched
 
 Option 1 is simpler but gives users no recovery path if the rewrite produces unexpected results. A `.bak` is trivial to create and provides a safety net without any extra cognitive overhead.
 
@@ -29,7 +29,7 @@ Option 2 gives maximum flexibility: users who want a diff-friendly workflow can 
 ## Rationale
 
 - In-place is the expected UX for a "migration" tool (lower friction)
-- `.bak` is zero-cost insurance — most users will never need it, but they'll be grateful when they do
+- `.bak` is zero-cost insurance; most users will never need it, but they'll be grateful when they do
 - `-OutputPath` enables review workflows and CI dry-run scenarios without a separate `-WhatIf` level of complexity
 - Consistent with how other script-rewriting tools in the ecosystem behave (e.g. `2to3`, `ps-upgrade`)
 
@@ -40,4 +40,4 @@ Option 2 gives maximum flexibility: users who want a diff-friendly workflow can 
 - `Convert-StepperScript` has a common `-OutputPath [string]` optional parameter
 - When `-OutputPath` is absent: reads source, writes `.bak`, writes rewritten content back to source
 - When `-OutputPath` is present: reads source, writes rewritten content to `-OutputPath`, source untouched, no `.bak`
-- `-WhatIf` support via `SupportsShouldProcess` — prints what would change without writing anything
+- `-WhatIf` support via `SupportsShouldProcess`; prints what would change without writing anything

--- a/Docs/adr/0005-cbh-injection-is-silent.md
+++ b/Docs/adr/0005-cbh-injection-is-silent.md
@@ -11,8 +11,8 @@
 `Repair-StepperScript` (and the first-run hook in `New-Step`) detects whether a user's script has comment-based help (CBH). If CBH is absent, Stepper can inject a skeleton block automatically.
 
 Two injection styles were considered:
-1. **Silent** — inject without prompting; emit one `Write-Verbose` call; continue execution
-2. **Interactive** — print a notice, call `exit`, require user to re-run (same pattern as `MissingCmdletBinding` in the old `Test-StepperScriptRequirements`)
+1. **Silent**: inject without prompting; emit one `Write-Verbose` call; continue execution
+2. **Interactive**: print a notice, call `exit`, require user to re-run (same pattern as `MissingCmdletBinding` in the old `Test-StepperScriptRequirements`)
 
 The `[CmdletBinding()]` and install-guard injections are already silent as of ADR 0003. CBH injection modifies the script in the same category of "structural improvement" as those two, and carries no functional risk (CBH is inert at runtime).
 
@@ -30,7 +30,7 @@ CBH injection is silent. No `Write-Host`, no `exit`, no user prompt. Consistent 
 
 - CBH is documentation-only; its absence or presence does not affect script execution
 - Interrupting execution for a non-functional change violates the principle of least surprise
-- Consistency with existing silent injections (ADR 0003) — users learn one mental model
+- Consistency with existing silent injections (ADR 0003); users learn one mental model
 - Verbose output is still emitted, so `-Verbose` users see what happened
 
 ---

--- a/Docs/adr/0006-new-steppersscript-showcase-switch.md
+++ b/Docs/adr/0006-new-steppersscript-showcase-switch.md
@@ -11,10 +11,10 @@
 `New-StepperScript` generates a new `.ps1` file pre-wired for Stepper. The question was how much content to include by default.
 
 Two extremes:
-1. **Minimal skeleton** — just the structural requirements: CBH, `[CmdletBinding()] param()`, install guard, two placeholder `New-Step` blocks, `Stop-Stepper`. Minimal noise, immediately editable.
-2. **Feature-showcase template** — everything in minimal, plus commented examples demonstrating named steps, `$Stepper.<var>` persistence, `-NoLog`, `-Retry`/`-RetryInterval`/`-MaxRetries`, and `#region Stepper ignore` blocks.
+1. **Minimal skeleton**: just the structural requirements: CBH, `[CmdletBinding()] param()`, install guard, two placeholder `New-Step` blocks, `Stop-Stepper`. Minimal noise, immediately editable.
+2. **Feature-showcase template**: everything in minimal, plus commented examples demonstrating named steps, `$Stepper.<var>` persistence, `-NoLog`, `-Retry`/`-RetryInterval`/`-MaxRetries`, and `#region Stepper ignore` blocks.
 
-Both templates can be useful in either situation — the right choice depends on intent, not experience level. A single fixed template forces a tradeoff: a minimal-only tool requires users to look up API details elsewhere; a showcase-only tool clutters files that just need a starting point.
+Both templates can be useful in either situation; the right choice depends on intent, not experience level. A single fixed template forces a tradeoff: a minimal-only tool requires users to look up API details elsewhere; a showcase-only tool clutters files that just need a starting point.
 
 The solution is a default of minimal with an opt-in flag for the full showcase.
 
@@ -28,9 +28,9 @@ The solution is a default of minimal with an opt-in flag for the full showcase.
 
 ## Rationale
 
-- Minimal is the right default because the common case is starting a new script, not exploring the API — less to delete, immediately writable
+- Minimal is the right default because the common case is starting a new script, not exploring the API; less to delete, immediately writable
 - Showcase is the right opt-in for any time you want in-file examples as a reference, regardless of experience level
-- Aliases make the flag discoverable — users who think `-Full` or `-WithExamples` are likely to get tab-completion
+- Aliases make the flag discoverable; users who think `-Full` or `-WithExamples` are likely to get tab-completion
 - Single implementation path per template variant (no runtime branching inside each `New-Step` block)
 
 ---

--- a/Docs/adr/0007-new-steppersscript-parameter-sets.md
+++ b/Docs/adr/0007-new-steppersscript-parameter-sets.md
@@ -10,8 +10,8 @@
 
 `New-StepperScript` needs a way to specify where to write the new script. Two calling styles exist in the wild:
 
-- `New-StepperScript -Path './scripts/Deploy.ps1'` — caller specifies a full path
-- `New-StepperScript -Name 'Deploy' -Directory './scripts'` — caller specifies name and location separately; the function constructs the path
+- `New-StepperScript -Path './scripts/Deploy.ps1'`: caller specifies a full path
+- `New-StepperScript -Name 'Deploy' -Directory './scripts'`: caller specifies name and location separately; the function constructs the path
 
 Both are idiomatic for PowerShell creation functions. `New-Item` uses `-Path`. `New-ADUser` and similar functions use `-Name` + a location parameter. Some users will have a full path from a variable; others want to type less by specifying just a name.
 
@@ -23,7 +23,7 @@ Supporting only one style forces awkward usage for the other half of callers.
 
 `New-StepperScript` uses two parameter sets:
 
-- **`ByPath`**: `-Path [string]` (mandatory) — full file path
+- **`ByPath`**: `-Path [string]` (mandatory): full file path
 - **`ByName`**: `-Name [string]` (mandatory) + `-Directory [string]` (optional, defaults to `$PWD`)
 
 Both produce identical output; `ByName` constructs the full path as `Join-Path $Directory "$Name.ps1"`.

--- a/Docs/adr/0008-test-repair-relationship-and-first-run-hook.md
+++ b/Docs/adr/0008-test-repair-relationship-and-first-run-hook.md
@@ -10,15 +10,15 @@
 
 Three related concerns need to be addressed:
 
-1. **Validation** — checking whether a script meets Stepper's structural requirements
-2. **Repair** — fixing issues found during validation
-3. **First-run hook** — `New-Step` currently calls `Test-StepperScriptRequirements` directly on first run to check/fix the calling script
+1. **Validation**: checking whether a script meets Stepper's structural requirements
+2. **Repair**: fixing issues found during validation
+3. **First-run hook**: `New-Step` currently calls `Test-StepperScriptRequirements` directly on first run to check/fix the calling script
 
 Three design options for the relationship between validation and repair:
 
-- **A. Independent** — `Test-` and `Repair-` share no code; both check and fix independently
-- **B. Shared private helper** — both call a `Find-StepperScriptIssues` private function; repair adds the fix layer
-- **C. Repair- calls Test-** — `Test-` is the source of truth; `Repair-` consumes its output and applies fixes
+- **A. Independent**: `Test-` and `Repair-` share no code; both check and fix independently
+- **B. Shared private helper**: both call a `Find-StepperScriptIssues` private function; repair adds the fix layer
+- **C. Repair- calls Test-**: `Test-` is the source of truth; `Repair-` consumes its output and applies fixes
 
 Option A duplicates detection logic. Option B is more modular but adds indirection for minimal benefit. Option C is the simplest directed composition: `Test-` has one job (find issues), `Repair-` has one job (fix what `Test-` found).
 
@@ -29,7 +29,7 @@ Option A duplicates detection logic. Option B is more modular but adds indirecti
 - `Test-StepperScript` is standalone: takes a path, returns a structured result, never modifies files
 - `Repair-StepperScript` calls `Test-StepperScript` internally: applies fixes for each fixable issue code, returns the post-fix `Test-StepperScript` result
 - `New-Step` first-run replaces the direct `Test-StepperScriptRequirements` call with `Repair-StepperScript`
-- `Test-StepperScriptRequirements` is deleted — it is a private function with no external callers
+- `Test-StepperScriptRequirements` is deleted; it is a private function with no external callers
 
 ---
 
@@ -40,13 +40,13 @@ Option A duplicates detection logic. Option B is more modular but adds indirecti
 - Callers who only want to check (not fix) can call `Test-` directly
 - Callers who want to check AND fix in one call use `Repair-`
 - First-run hook in `New-Step` needs repair semantics (it must fix, not just report)
-- `Test-StepperScriptRequirements` was private with a single caller (`New-Step`), which is now updated — there is nothing to be backward-compatible with
+- `Test-StepperScriptRequirements` was private with a single caller (`New-Step`), which is now updated; there is nothing to be backward-compatible with
 
 ---
 
 ## Consequences
 
-- `Test-StepperScript` output shape: `{ Path, IsValid, Issues[] }` — never writes files
+- `Test-StepperScript` output shape: `{ Path, IsValid, Issues[] }`; never writes files
 - `Repair-StepperScript` output: same shape as `Test-StepperScript`, reflects post-repair state
 - `New-Step.ps1`: replace `Test-StepperScriptRequirements` call with `Repair-StepperScript -ScriptPath $scriptPath`
 - `Test-StepperScriptRequirements.ps1` and its test file are deleted

--- a/Docs/adr/0009-approved-verb-split-test-repair.md
+++ b/Docs/adr/0009-approved-verb-split-test-repair.md
@@ -1,4 +1,4 @@
-# ADR 0009: Approved verb split — Test-StepperScript and Repair-StepperScript; Validate- rejected
+# ADR 0009: Approved verb split: Test-StepperScript and Repair-StepperScript; Validate- rejected
 
 **Date:** 2026-05-01
 **Status:** Accepted
@@ -13,8 +13,8 @@ The initial feature request used "Validate-StepperScript" as a working name for 
 `Validate` is not in the PowerShell approved verb list (`Get-Verb` returns no match for `Validate`). Using an unapproved verb causes `Test-ModuleManifest` warnings and breaks `PSScriptAnalyzer` lint rules. It also confuses tab-completion and discoverability.
 
 The approved verbs covering the intended semantics are:
-- `Test-` — performs a check and returns a result (boolean or structured)
-- `Repair-` — fixes something that is broken or incomplete
+- `Test-` : performs a check and returns a result (boolean or structured)
+- `Repair-` : fixes something that is broken or incomplete
 
 Both semantics are needed: users may want to check without modifying (CI pipeline, pre-flight review), and users may want to automatically fix issues (first-run hook, developer setup).
 

--- a/Docs/adr/0010-extract-new-issue-to-private-function.md
+++ b/Docs/adr/0010-extract-new-issue-to-private-function.md
@@ -20,24 +20,24 @@ function New-Issue {
 
 This pattern has several problems:
 
-1. **Redefined on every call** — PowerShell re-parses and rebinds the nested function
+1. **Redefined on every call**: PowerShell re-parses and rebinds the nested function
    definition each time `Test-StepperScript` is invoked. No caching, no reuse.
-2. **Violates one-function-per-file** — project convention (enforced for `New-StepperScript`
+2. **Violates one-function-per-file**: project convention (enforced for `New-StepperScript`
    in the same codebase) requires each function to live in its own `.ps1` file.
-3. **No `[CmdletBinding()]`** — the nested function lacks the required attribute, making it
+3. **No `[CmdletBinding()]`**: the nested function lacks the required attribute, making it
    a simple function rather than an advanced function. No common parameters, no
    `$PSCmdlet` support.
-4. **No comment-based help** — undiscoverable and undocumented.
-5. **No `ValidateSet` on `$Severity`** — callers could pass any string; the private file
+4. **No comment-based help**: undiscoverable and undocumented.
+5. **No `ValidateSet` on `$Severity`**: callers could pass any string; the private file
    adds `[ValidateSet('Error', 'Warning')]` to enforce the domain values.
-6. **Not independently testable** — nested scope means it cannot be dot-sourced or
+6. **Not independently testable**: nested scope means it cannot be dot-sourced or
    unit-tested in isolation.
 
 Two alternatives were considered:
 
-- **Inline the `[PSCustomObject]@{}` at each call site** — removes the function entirely
+- **Inline the `[PSCustomObject]@{}` at each call site**: removes the function entirely
   but duplicates the object shape at 5 call sites. Harder to change the shape later.
-- **Extract to `Private/New-StepperIssue.ps1`** — single source of truth, independently
+- **Extract to `Private/New-StepperIssue.ps1`**: single source of truth, independently
   testable, follows project conventions, gets `[CmdletBinding()]` and CBH for free.
 
 ---
@@ -58,7 +58,7 @@ The test file's `BeforeAll` dot-sources it explicitly alongside the other privat
 
 ## Consequences
 
-- `Test-StepperScript` is simpler — no nested function definition in the body.
+- `Test-StepperScript` is simpler; no nested function definition in the body.
 - `New-StepperIssue` is independently testable if issue-object shape ever needs to change.
 - `[ValidateSet('Error', 'Warning')]` on `$Severity` makes invalid severity strings a
   parse-time error rather than a silent bug.

--- a/Docs/adr/0011-in-script-sentinel-for-conversion.md
+++ b/Docs/adr/0011-in-script-sentinel-for-conversion.md
@@ -8,15 +8,15 @@
 
 ## Context
 
-`ConvertTo-StepperScript` rewrites cross-step variable references inside `New-Step` blocks. It is invoked interactively during `New-Step`'s first-run hook (after `Repair-StepperScript`). The offer must be made at most once per script — re-prompting on every first run would be disruptive and confusing.
+`ConvertTo-StepperScript` rewrites cross-step variable references inside `New-Step` blocks. It is invoked interactively during `New-Step`'s first-run hook (after `Repair-StepperScript`). The offer must be made at most once per script; re-prompting on every first run would be disruptive and confusing.
 
 Three sentinel strategies were considered:
 
-1. **State file key** — store `ConversionOffered = $true` in the Stepper state JSON. Cheap, no extra files. Disappears when the state is cleared (e.g. after `Stop-Stepper` on successful completion), so the offer reappears on the next full run.
+1. **State file key**: store `ConversionOffered = $true` in the Stepper state JSON. Cheap, no extra files. Disappears when the state is cleared (e.g. after `Stop-Stepper` on successful completion), so the offer reappears on the next full run.
 
-2. **Sidecar file** — write a `.stepper-converted` marker file alongside the script. Survives all run cycles. Adds mystery files to the user's project; clutters source control.
+2. **Sidecar file**: write a `.stepper-converted` marker file alongside the script. Survives all run cycles. Adds mystery files to the user's project; clutters source control.
 
-3. **In-script sentinel variable** — inject `$StepperConversionComplete = $true` into the script itself after rewriting. The script is already modified by `ConvertTo-StepperScript`, so this is no additional mechanism. Survives all run cycles. No extra files. Visible and self-documenting. Deliberate revert requires deliberate removal of the sentinel, which is appropriate.
+3. **In-script sentinel variable**: inject `$StepperConversionComplete = $true` into the script itself after rewriting. The script is already modified by `ConvertTo-StepperScript`, so this is no additional mechanism. Survives all run cycles. No extra files. Visible and self-documenting. Deliberate revert requires deliberate removal of the sentinel, which is appropriate.
 
 ---
 
@@ -29,7 +29,7 @@ Three sentinel strategies were considered:
 ## Rationale
 
 - the script is already being modified, so one more injected line is zero extra complexity
-- no sidecar files — the script itself is the authoritative record of conversion
+- no sidecar files; the script itself is the authoritative record of conversion
 - survives `Stop-Stepper`, state wipes, and re-clones without needing the state file
 - self-documenting: anyone reading the script can see that conversion has already run
 - if a user reverts the rewrite manually, removing the sentinel is an appropriate and obvious step
@@ -39,6 +39,6 @@ Three sentinel strategies were considered:
 ## Consequences
 
 - `ConvertTo-StepperScript` gains responsibility for injecting `$StepperConversionComplete = $true` after rewriting
-- `New-Step` first-run hook checks for the sentinel via AST scan (not `Test-Path Variable:StepperConversionComplete`) — the sentinel lives at script scope but `New-Step` is a function call; the variable is not in scope at the time of the check. `Get-ScriptAst` + `FindAll` for `VariableExpressionAst` named `StepperConversionComplete` is the correct approach, consistent with how `Find-CrossStepVariables` works
+- `New-Step` first-run hook checks for the sentinel via AST scan (not `Test-Path Variable:StepperConversionComplete`); the sentinel lives at script scope but `New-Step` is a function call; the variable is not in scope at the time of the check. `Get-ScriptAst` + `FindAll` for `VariableExpressionAst` named `StepperConversionComplete` is the correct approach, consistent with how `Find-CrossStepVariables` works
 - scripts that were rewritten before this ADR will not have the sentinel; the first-run hook will offer conversion once more and then inject it
 - `Find-CrossStepVariables` should treat `$Stepper.*` references as already-converted and exclude them from candidates

--- a/Docs/adr/0012-centralized-backup-function.md
+++ b/Docs/adr/0012-centralized-backup-function.md
@@ -10,11 +10,11 @@
 
 Several Stepper functions modify the caller's script on disk:
 
-- `Add-StepperCbh` — injects comment-based help
-- `Repair-StepperScript` — adds `[CmdletBinding()]`, install guard
-- `Update-ScriptWithUnmanagedActions` — wraps unmanaged code blocks
-- `New-Step` — appends `Stop-Stepper`
-- `ConvertTo-StepperScript` — rewrites cross-step variable references
+- `Add-StepperCbh`: injects comment-based help
+- `Repair-StepperScript`: adds `[CmdletBinding()]`, install guard
+- `Update-ScriptWithUnmanagedActions`: wraps unmanaged code blocks
+- `New-Step`: appends `Stop-Stepper`
+- `ConvertTo-StepperScript`: rewrites cross-step variable references
 
 Each was independently responsible for producing a backup (or not). `ConvertTo-StepperScript` wrote a flat `<name>.ps1.bak` alongside the source. The other four wrote no backup at all, meaning unrecoverable changes could be made to user scripts silently.
 
@@ -22,7 +22,7 @@ Each was independently responsible for producing a backup (or not). `ConvertTo-S
 
 ## Decision
 
-Introduce `Private/New-StepperBackup.ps1` — a single private function that all script-writing callers invoke immediately before writing. It produces a timestamped backup named:
+Introduce `Private/New-StepperBackup.ps1`: a single private function that all script-writing callers invoke immediately before writing. It produces a timestamped backup named:
 
 ```
 <BaseName>.<yyyy.M.dHHmm>.ps1.bak
@@ -38,13 +38,13 @@ in the same directory as the source file. The CalVer timestamp matches the proje
 - the CalVer timestamp format is consistent with the project's versioning convention and sorts lexicographically
 - placing the backup in the same directory as the source mirrors the `ConvertTo-StepperScript` convention users were already accustomed to
 - flat `.bak` suffix with no extension stack (not `.ps1`) was rejected because Windows/macOS file type associations would not be confused by `.ps1.bak`, and keeping `.ps1.bak` makes the backup recognisable as PowerShell source
-- backup before every write, even when the change is structural (CBH, guard), is the safe default — users can delete stale backups, but they cannot un-lose overwritten code
+- backup before every write, even when the change is structural (CBH, guard), is the safe default; users can delete stale backups, but they cannot un-lose overwritten code
 
 ---
 
 ## Consequences
 
 - `Add-StepperCbh`, `Repair-StepperScript`, `Update-ScriptWithUnmanagedActions`, `New-Step`, and `ConvertTo-StepperScript` each call `New-StepperBackup -Path $ScriptPath | Out-Null` immediately before writing
-- `ConvertTo-StepperScript` no longer writes a flat `.ps1.bak`; the timestamped `.ps1.bak` replaces it — existing tests that assert the old flat backup filename are updated accordingly
+- `ConvertTo-StepperScript` no longer writes a flat `.ps1.bak`; the timestamped `.ps1.bak` replaces it; existing tests that assert the old flat backup filename are updated accordingly
 - repeated runs of a Stepper-enabled script on the same day and hour will overwrite the backup from the same minute (same timestamp); in practice this is fine because the user is running the script interactively and the minute-resolution window is narrow
-- the function is `Private` — not exported, not in the manifest's `FunctionsToExport`
+- the function is `Private`; not exported, not in the manifest's `FunctionsToExport`

--- a/Docs/api-reference.md
+++ b/Docs/api-reference.md
@@ -13,7 +13,7 @@ New-Step [-ScriptBlock] <scriptblock> [-LogPath <string>] [-NoLog] [-Retry] [-Re
 |---|---|---|---|
 | `Name` | `string` | No | Display name shown in prompts and verbose output |
 | `ScriptBlock` | `scriptblock` | Yes | The code to execute |
-| `LogPath` | `string` | No | Path to the log file. Overrides the default (`<scriptname>.ps1.stepper.log`). Only needs to be specified once — Stepper resolves it via AST scan at init time. |
+| `LogPath` | `string` | No | Path to the log file. Overrides the default (`<scriptname>.ps1.stepper.log`). Only needs to be specified once. Stepper resolves it via AST scan at init time. |
 | `NoLog` | `switch` | No | Exclude this step from logging. At init time Stepper prompts to choose scope: log all / skip flagged / disable entirely. |
 | `Retry` | `switch` | No | Enable exponential backoff retry for this step. |
 | `RetryInterval` | `int` | No | Base interval in seconds between retries. Each attempt waits `RetryInterval * 2^attempt` seconds. Default: `60`. Minimum: `1`. Requires `-Retry`. |
@@ -23,6 +23,27 @@ New-Step [-ScriptBlock] <scriptblock> [-LogPath <string>] [-NoLog] [-Retry] [-Re
 Must be called from a saved `.ps1` file. Does not work from the console or an unsaved editor buffer.
 
 See [Logging](logging.md) for full details on log format, step transcripts, and active transcript conflict handling.
+
+### Retry Behavior
+
+When `-Retry` is specified, the `ScriptBlock` runs inside an exponential backoff loop:
+v
+- On each failure, Stepper waits `RetryInterval * 2^attempt` seconds and retries
+- The loop continues until the block succeeds or `MaxRetries` is exhausted
+- If all attempts fail, Stepper propagates a terminating error and stops
+
+**Important: local variables reset on every execution.** The `ScriptBlock` is re-invoked from scratch on each retry, so any local variable you assign is re-initialized on the next attempt. Use `$Stepper.*` keys to accumulate state across retries:
+
+```powershell
+New-Step 'Call API' -Retry -RetryInterval 5 -MaxRetries 4 {
+    if ($null -eq $Stepper.RetryCount) { $Stepper.RetryCount = 0 }
+    $Stepper.RetryCount++
+    Write-Host "Attempt $($Stepper.RetryCount)..."
+    Invoke-RestMethod https://api.example.com/data
+}
+```
+
+`$Stepper.RetryCount` persists because it is stored in the `$Stepper` hashtable, which is serialized to the state file and restored between attempts.
 
 ## `Stop-Stepper`
 
@@ -51,7 +72,7 @@ New-StepperScript [-Name] <string> [-Directory <string>] [-Force] [-Showcase]
 | `Force` | `switch` | No | Overwrite if the target file already exists |
 | `Showcase` | `switch` | No | Generate the full feature-showcase template (aliases: `-Full`, `-Detailed`, `-WithExamples`) |
 
-Returns `[System.IO.FileInfo]` — the created file, suitable for pipeline use.
+Returns `[System.IO.FileInfo]`: the created file, suitable for pipeline use.
 
 Both the minimal and showcase templates pass `Test-StepperScript` with `IsValid = $true` out of the box.
 
@@ -111,13 +132,48 @@ Fixes applied automatically:
 
 The following are reported via `Write-Warning` but **not** automatically fixed (require author decision):
 
-- `MissingStopStepper` — placement depends on script structure
-- `NoSteps` — may be intentional during authoring
+- `MissingStopStepper`: placement depends on script structure
+- `NoSteps`: may be intentional during authoring
 
 Returns the post-fix result of `Test-StepperScript`. If no changes were needed, the script file is not modified. Supports `-WhatIf`.
 
+## `ConvertTo-StepperScript`
+
+Detects variables that cross step boundaries and rewrites them to `$Stepper.<Var>` notation so they persist across steps and resume correctly after a crash.
+
+Called automatically on first run via `New-Step` when the conversion sentinel (`$StepperConversionComplete`) is absent. Can also be run manually at any time.
+
+```powershell
+ConvertTo-StepperScript [-Path] <string> [-OutputPath <string>] [-Force] [-WhatIf]
+ConvertTo-StepperScript -Name <string> [-Directory <string>] [-OutputPath <string>] [-Force] [-WhatIf]
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `Path` | `string` | Yes (ByPath) | Path to the `.ps1` file to convert |
+| `Name` | `string` | Yes (ByName) | Script name with or without `.ps1`. Used with `-Directory` |
+| `Directory` | `string` | No | Directory for `-Name` mode. Defaults to `$PWD` |
+| `OutputPath` | `string` | No | Write converted content here instead of modifying the source. No backup is created when set |
+| `Force` | `switch` | No | Skip per-variable confirmation and convert all candidates |
+
+**Variable detection rules.** A variable is a candidate if it is:
+
+1. Assigned in one `New-Step` block and read in a later block
+2. Assigned in unmanaged (script-level) code and read inside any step
+3. Both assigned and read inside the same `-Retry` step (local variables reset on every retry attempt)
+
+When candidates are found, ConvertTo prompts for each:
+
+```
+[Y] Yes (default)   [n] No, skip   [a] All, convert remaining   [q] Quit
+```
+
+On completion, `$StepperConversionComplete = $true` is injected inside `#region Stepper ignore`. `New-Step` checks for this sentinel and skips the conversion hook on all subsequent runs.
+
+A timestamped backup (`<BaseName>.<yyyy.M.dHHmm>.ps1.bak`) is created alongside the script before any write.
+
 ## Error Handling
 
-- If a step throws, Stepper propagates a terminating error with step context (identifier, name, number). State is **not** saved for the failed step — on resume, that step re-executes.
+- If a step throws, Stepper propagates a terminating error with step context (identifier, name, number). State is **not** saved for the failed step. On resume, that step re-executes.
 - `[CmdletBinding()]` in the calling script is required for error propagation to work correctly. Stepper auto-injects it if missing (see [How It Works](how-it-works.md)).
 - All file I/O errors are surfaced as typed `ErrorRecord` objects, not raw exceptions.

--- a/Docs/data-persistence.md
+++ b/Docs/data-persistence.md
@@ -41,7 +41,7 @@ Stepper stores state in `<scriptname>.ps1.stepper` alongside the script, using P
 | `Timestamp` | ISO 8601 datetime |
 | `StepperData` | Serialized `$Stepper` hashtable |
 | `LogPath` | Resolved path to the log file, or `$null` if logging is disabled |
-| `LoggingEnabled` | `$true` unless the user chose `[N]` at the scope prompt |
+| `LoggingEnabled` | `$true` unless the user chose `[d]` at the scope prompt |
 | `NoLogStepIds` | Array of `filepath:lineNumber` identifiers for steps with `-NoLog` |
 
 **Manual inspection:**
@@ -50,4 +50,4 @@ Stepper stores state in `<scriptname>.ps1.stepper` alongside the script, using P
 Import-Clixml .\myscript.ps1.stepper
 ```
 
-Manual deletion is always safe — the next run simply starts fresh.
+Manual deletion is always safe; the next run simply starts fresh.

--- a/Docs/examples.md
+++ b/Docs/examples.md
@@ -7,7 +7,7 @@
 param()
 
 #region Stepper ignore
-# This runs every time — safe to leave outside New-Step
+# This runs every time. Safe to leave outside New-Step
 $outputDir = Join-Path $PSScriptRoot 'output'
 #endregion Stepper ignore
 
@@ -25,7 +25,7 @@ New-Step 'Download Data' {
 }
 
 New-Step {
-    # Unnamed step — backward-compatible syntax
+    # Unnamed step (backward-compatible syntax)
     foreach ($file in $Stepper.Files) {
         Write-Host "Processing $file in $($Stepper.OutputDir)..."
     }

--- a/Docs/how-it-works.md
+++ b/Docs/how-it-works.md
@@ -1,12 +1,13 @@
 # How It Works
 
-## First Run — Script Validation
+## First Run Script Validation
 
 Before executing any steps, Stepper validates the script:
 
-1. Checks for `[CmdletBinding()]` and the self-install guard independently — each is silently injected if missing. The guard is wrapped in `#region Stepper ignore` so it won't trigger unmanaged-code warnings on the next run. No prompt, no `#Requires` statement added.
-2. Scans for unmanaged code between `New-Step` blocks — prompts per block: Wrap / Mark / Delete / Ignore
+1. Checks for `[CmdletBinding()]` and the self-install guard independently. Each component is silently injected if missing. The guard is wrapped in `#region Stepper ignore` so it won't trigger unmanaged-code warnings on the next run. No prompt, no `#Requires` statement added.
+2. Scans for unmanaged code between `New-Step` blocks then prompts per block: Wrap / Mark / Delete / Ignore
 3. Checks that `Stop-Stepper` appears at the end
+4. If the `$StepperConversionComplete` sentinel is absent, invokes `ConvertTo-StepperScript` to detect and migrate cross-step variables to `$Stepper.<Var>` notation. On completion, ConvertTo injects `$StepperConversionComplete = $true` inside `#region Stepper ignore`. The hook is skipped on all subsequent runs.
 
 If the script is modified by any of the above, Stepper writes the changes and asks you to re-run.
 
@@ -16,22 +17,22 @@ If the script is modified by any of the above, Stepper writes the changes and as
 - After each step succeeds, state is serialized to a `.stepper` file (XML via `Export-Clixml`) in the same directory as the script
 - State includes: SHA256 hash, full script contents, last completed step, step name/number, timestamp (ISO 8601), and the full `$Stepper` hashtable
 
-## Resume — Script Unchanged
+## Resume, Script Unchanged
 
 On the next run, Stepper finds the `.stepper` file, computes the current SHA256, and if it matches prompts:
 
 ```
-[R] Resume (default)   [S] Start over   [M] More details   [Q] Quit
+[R] Resume (default)   [s] Start over   [m] More details   [q] Quit
 ```
 
 Resume mode skips all steps up to and including `LastCompletedStep` and continues from the next one.
 
-## Resume — Script Modified
+## Resume, Script Modified
 
 If the hash doesn't match, Stepper warns about the inconsistency and prompts:
 
 ```
-[R] Resume (risky)   [S] Start over   [M] More details   [Q] Quit
+[r] Resume (risky)   [S] Start over (default)   [m] More details   [q] Quit
 ```
 
 Start over removes the state file and runs fresh.
@@ -57,8 +58,9 @@ When `Read-Host` is unavailable (CI/CD, remoting, unattended runs), Stepper fall
 |---|---|
 | Missing `[CmdletBinding()]` | Silent auto-inject (always; no prompt) |
 | Unmanaged code | Wrap |
-| Resume — script unchanged | Resume |
-| Resume — script modified | Start over |
+| Resume, script unchanged | Resume |
+| Resume, script modified | Start over |
+| Cross-step variable conversion | Convert all |
 
 ## Verbose Output
 

--- a/Docs/logging.md
+++ b/Docs/logging.md
@@ -22,7 +22,7 @@ New-Step 'Install Packages' -LogPath 'C:\Logs\deploy.log' {
 }
 ```
 
-You only need to specify `-LogPath` once — Stepper uses the first value found via AST scan and applies it to all steps. If multiple steps specify **different** `-LogPath` values, Stepper prompts at init time to choose one. Dynamic paths (variables or expressions) cannot be resolved at scan time; the first runtime value wins and a warning is emitted if a later step provides a different one.
+You only need to specify `-LogPath` once in the script. Stepper uses the first value found via AST scan and applies it to all steps. If multiple steps specify **different** `-LogPath` values, Stepper prompts at init time to choose one. Dynamic paths (variables or expressions) cannot be resolved at scan time; the first runtime value wins and a warning is emitted if a later step provides a different one.
 
 If the directory for the specified `-LogPath` does not exist, Stepper throws a terminating error before executing any steps.
 
@@ -42,15 +42,15 @@ When `-NoLog` is present on any step, Stepper prompts at init time:
 
 ```
 One or more steps have -NoLog. How should logging be scoped?
-[A] Log all steps   [S] Skip only flagged steps   [N] Disable entirely   [Q] Quit
+[A] Log all steps (default)   [s] Skip only flagged steps   [d] Disable entirely   [q] Quit
 ```
 
 | Choice | Behavior |
 |---|---|
-| `[A]` | Log all steps, ignore `-NoLog` flags |
-| `[S]` | Skip transcript/log for flagged steps only |
-| `[D]` | Disable logging entirely for this run |
-| `[Q]` | Exit without running |
+| `[A]` | Log all steps, ignore `-NoLog` flags (default) |
+| `[s]` | Skip transcript/log for flagged steps only |
+| `[d]` | Disable logging entirely for this run |
+| `[q]` | Exit without running |
 
 In non-interactive mode (CI/CD, remoting), the default is `[A]`.
 

--- a/Docs/named-steps.md
+++ b/Docs/named-steps.md
@@ -4,7 +4,7 @@ Steps can be given names for clearer resume prompts and verbose output.
 
 ```powershell
 New-Step 'Download Files' {
-    # positional — preferred
+    # positional (preferred)
     Write-Host "Step: $($Stepper.StepName), number: $($Stepper.StepNumber)"
 }
 
@@ -14,7 +14,7 @@ New-Step -Name 'Process Data' {
 }
 
 New-Step {
-    # unnamed — backward-compatible, always works
+    # unnamed (backward-compatible, always works)
     Write-Host "No name, no problem."
 }
 ```
@@ -33,7 +33,7 @@ New-Step {
 
 Available inside every block:
 
-- `$Stepper.StepName` — the name passed to `New-Step`, or `$null` if unnamed
-- `$Stepper.StepNumber` — 1-based index of the current step
+- `$Stepper.StepName`: the name passed to `New-Step`, or `$null` if unnamed
+- `$Stepper.StepNumber`: 1-based index of the current step
 
 Both values are persisted to the state file as `LastCompletedStepName` and `LastCompletedStepNumber`.

--- a/Docs/plan/stepper-script-management.md
+++ b/Docs/plan/stepper-script-management.md
@@ -10,18 +10,18 @@
 
 Add four public functions and two private helpers to improve the Stepper user experience:
 
-1. `Test-StepperScript` — validate a script's Stepper compatibility, return structured results
-2. `Repair-StepperScript` — fix issues found by Test-StepperScript, replace first-run repair hook
-3. `Convert-StepperScript` — migrate plain variables to `$Stepper.<var>` via interactive AST-driven rewrite
-4. `New-StepperScript` — create a new script pre-wired for Stepper use
-5. (Private) `Find-CrossStepVariables` — AST analysis supporting Convert-StepperScript
-6. (Private) `Add-StepperCbh` — CBH injection/augmentation supporting Repair-StepperScript
+1. `Test-StepperScript` : validate a script's Stepper compatibility, return structured results
+2. `Repair-StepperScript` : fix issues found by Test-StepperScript, replace first-run repair hook
+3. `Convert-StepperScript` : migrate plain variables to `$Stepper.<var>` via interactive AST-driven rewrite
+4. `New-StepperScript` : create a new script pre-wired for Stepper use
+5. (Private) `Find-CrossStepVariables` : AST analysis supporting Convert-StepperScript
+6. (Private) `Add-StepperCbh` : CBH injection/augmentation supporting Repair-StepperScript
 
 Refactor `New-Step` first-run behavior to call `Repair-StepperScript` directly.
 
 ---
 
-## Phase 1 — Private helpers
+## Phase 1: Private helpers
 
 ### `Private/Find-CrossStepVariables.ps1`
 
@@ -47,12 +47,12 @@ Inspects a script's AST for comment-based help via `ScriptBlockAst.GetHelpConten
 - If no CBH exists: inserts a full CBH block with `.SYNOPSIS`, `.DESCRIPTION`, `.NOTES`
 - If CBH exists but has no `.NOTES`: appends `.NOTES` section with Stepper usage blurb
 - If `.NOTES` exists: appends Stepper usage blurb to the existing `.NOTES`
-- Silent (no Write-Host, no user prompt) — consistent with CmdletBinding injection
+- Silent (no Write-Host, no user prompt); consistent with CmdletBinding injection
 - Returns `$true` if the script was modified, `$false` otherwise
 
 ---
 
-## Phase 2 — `Test-StepperScript`
+## Phase 2: `Test-StepperScript`
 
 **File:** `Public/Test-StepperScript.ps1`
 
@@ -97,7 +97,7 @@ Each issue:
 
 ---
 
-## Phase 3 — `Repair-StepperScript`
+## Phase 3: `Repair-StepperScript`
 
 **File:** `Public/Repair-StepperScript.ps1`
 
@@ -118,7 +118,7 @@ Returns the `Test-StepperScript` result object (post-fix state).
 
 ---
 
-## Phase 4 — `New-Step` first-run refactor
+## Phase 4: `New-Step` first-run refactor
 
 **File:** `Public/New-Step.ps1`
 
@@ -128,7 +128,7 @@ No user-visible behavior change.
 
 ---
 
-## Phase 5 — `Convert-StepperScript`
+## Phase 5: `Convert-StepperScript`
 
 **File:** `Public/Convert-StepperScript.ps1`
 
@@ -156,7 +156,7 @@ Common:
 4. Present each candidate interactively (y/n/all/quit style)
 5. Collect confirmed variable names
 6. AST-walk: collect ALL `VariableExpressionAst` occurrences of each selected var
-   that are INSIDE any `New-Step` scriptblock body — collect `Extent.StartOffset` and `Extent.EndOffset`
+   that are INSIDE any `New-Step` scriptblock body, collect `Extent.StartOffset` and `Extent.EndOffset`
 7. Sort occurrences by `StartOffset` descending (back-to-front rewrite preserves offsets)
 8. Rewrite script text: replace `$varname` with `$Stepper.Varname`
 9. Write output (in-place + .bak, or -OutputPath)
@@ -169,7 +169,7 @@ Does NOT rename occurrences outside step blocks (e.g. script-level code, param b
 
 ---
 
-## Phase 6 — `New-StepperScript`
+## Phase 6: `New-StepperScript`
 
 **File:** `Public/New-StepperScript.ps1`
 
@@ -190,7 +190,7 @@ Common:
 
 ### Output
 
-`[System.IO.FileInfo]` — the created file, for pipeline use.
+`[System.IO.FileInfo]`: the created file, for pipeline use.
 
 ### Templates
 
@@ -232,5 +232,5 @@ Regression gate: full existing suite must pass after Phase 4 refactor.
 - `Tests/New-StepperScript.Tests.ps1`
 
 ### Modified
-- `Public/New-Step.ps1` — first-run hook calls `Repair-StepperScript`
-- `Private/Test-StepperScriptRequirements.ps1` — deleted (private, no external callers)
+- `Public/New-Step.ps1`: first-run hook calls `Repair-StepperScript`
+- `Private/Test-StepperScriptRequirements.ps1`: deleted (private, no external callers)

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -26,4 +26,4 @@ A PowerShell transcript is already running (e.g., started in `$PROFILE` or by an
 
 **`Read-Host` prompts and responses don't appear in the log file**
 
-`Start-Transcript` on macOS/Linux (PS Core) does not capture `Read-Host` input. This is a platform limitation — all other output (`Write-Host`, pipeline, etc.) is captured normally. On Windows the behavior is the same in both PS 5.1 and PS 7.
+`Start-Transcript` on macOS/Linux (PS Core) does not capture `Read-Host` input. This is a platform limitation; all other output (`Write-Host`, pipeline, etc.) is captured normally. On Windows the behavior is the same in both PS 5.1 and PS 7.

--- a/Docs/unmanaged-code.md
+++ b/Docs/unmanaged-code.md
@@ -22,7 +22,7 @@ The following are always safe outside blocks:
 For each flagged block, Stepper prompts:
 
 ```
-[W] Wrap in New-Step (default)   [M] Mark as ignored   [D] Delete   [I] Ignore   [Q] Quit
+[W] Wrap in New-Step block (default)   [m] Mark as expected to ignore   [d] Delete this code   [i] Ignore and continue   [q] Quit
 ```
 
 ## The `#region Stepper ignore` Directive

--- a/Private/Add-StepperCbh.ps1
+++ b/Private/Add-StepperCbh.ps1
@@ -42,7 +42,7 @@ function Add-StepperCbh {
     $cbhMatch   = [regex]::Match($content, $cbhPattern)
 
     if (-not $cbhMatch.Success) {
-        # No CBH at all — insert a full block at the very top
+        # No CBH at all... insert a full block at the very top
         $scriptName = [System.IO.Path]::GetFileNameWithoutExtension($ScriptPath)
         $newCbh     = @(
             '<#'
@@ -70,12 +70,12 @@ function Add-StepperCbh {
         return $false
     }
 
-    # CBH exists — does it have a .NOTES section?
+    # CBH exists... does it have a .NOTES section?
     $notesPattern = '(?s)(\.NOTES\s*\r?\n)(.*?)(\r?\n\s*(?:\.[A-Z]|#>))'
     $notesMatch   = [regex]::Match($cbhText, $notesPattern)
 
     if ($notesMatch.Success) {
-        # .NOTES exists — append blurb inside it
+        # .NOTES exists... append blurb inside it
         $insertion = $notesMatch.Groups[1].Value +
                      $notesMatch.Groups[2].Value +
                      [System.Environment]::NewLine + "    $stepperBlurb" +
@@ -84,7 +84,7 @@ function Add-StepperCbh {
             $notesMatch.Index, $insertion
         )
     } else {
-        # No .NOTES — insert one before closing #>
+        # No .NOTES... insert one before closing #>
         $closeIdx  = $cbhText.LastIndexOf('#>')
         $notesBlock = [System.Environment]::NewLine + ".NOTES" +
                       [System.Environment]::NewLine + "    $stepperBlurb" +

--- a/Private/Find-NewStepBlocks.ps1
+++ b/Private/Find-NewStepBlocks.ps1
@@ -21,8 +21,8 @@ function Find-NewStepBlocks {
 
     .OUTPUTS
         Hashtable with:
-          NewStepBlocks   — array of @{ Start; End } (0-based line indices)
-          StopStepperLine — 0-based line index of Stop-Stepper, or -1 if absent
+          NewStepBlocks: array of @{ Start; End } (0-based line indices)
+          StopStepperLine: 0-based line index of Stop-Stepper, or -1 if absent
     #>
     [CmdletBinding(DefaultParameterSetName = 'Path')]
     param(
@@ -47,7 +47,7 @@ function Find-NewStepBlocks {
         $ast = [System.Management.Automation.Language.Parser]::ParseInput($ScriptContent, [ref]$tokens, [ref]$errors)
     }
 
-    # Find all New-Step command calls — AST correctly ignores occurrences inside strings/comments
+    # Find all New-Step command calls. AST correctly ignores occurrences inside strings/comments
     $newStepCalls = $ast.FindAll({
         $args[0] -is [System.Management.Automation.Language.CommandAst] -and
         $args[0].GetCommandName() -eq 'New-Step'
@@ -61,7 +61,7 @@ function Find-NewStepBlocks {
         }
     }
 
-    # Find Stop-Stepper — take the first occurrence
+    # Find Stop-Stepper, take the first occurrence
     $stopCalls = $ast.FindAll({
         $args[0] -is [System.Management.Automation.Language.CommandAst] -and
         $args[0].GetCommandName() -eq 'Stop-Stepper'

--- a/Private/Find-UnmanagedCodeBlocks.ps1
+++ b/Private/Find-UnmanagedCodeBlocks.ps1
@@ -9,7 +9,7 @@ function Find-UnmanagedCodeBlocks {
           - #region Stepper ignore / #endregion Stepper ignore regions
           - Executable lines via AST statement extents rather than a regex whitelist
 
-        Parameter signature is unchanged from the regex implementation — $ScriptLines is
+        Parameter signature is unchanged from the regex implementation. $ScriptLines is
         joined internally for parsing, and line indices in the return value remain 0-based.
 
     .PARAMETER ScriptLines
@@ -40,7 +40,7 @@ function Find-UnmanagedCodeBlocks {
 
     $unmanagedBlocks = @()
 
-    # Parse via AST — join lines so token extents match 0-based array indices (+1 for 1-based)
+    # Parse via AST. Join lines so token extents match 0-based array indices (+1 for 1-based)
     $scriptContent = $ScriptLines -join [System.Environment]::NewLine
     $tokens = $null
     $parseErrors = $null

--- a/Private/Get-ScriptAst.ps1
+++ b/Private/Get-ScriptAst.ps1
@@ -18,9 +18,9 @@ function Get-ScriptAst {
 
     .OUTPUTS
         PSCustomObject with properties:
-          Ast    — [System.Management.Automation.Language.ScriptBlockAst]
-          Tokens — [System.Management.Automation.Language.Token[]]
-          Errors — [System.Management.Automation.Language.ParseError[]]
+          Ast: [System.Management.Automation.Language.ScriptBlockAst]
+          Tokens: [System.Management.Automation.Language.Token[]]
+          Errors: [System.Management.Automation.Language.ParseError[]]
 
     .NOTES
         Line number convention: AST Extent properties (StartLineNumber, EndLineNumber) are 1-based.

--- a/Private/Get-StepInventory.ps1
+++ b/Private/Get-StepInventory.ps1
@@ -13,9 +13,9 @@ function Get-StepInventory {
 
     .OUTPUTS
         PSCustomObject with properties:
-          StepLines  — string[] of "$ScriptPath:$lineNumber" (1-based), one per step
-          StepNames  — string[] (or $null entries) of step names in the same order
-          TotalSteps — int count of steps
+          StepLines: string[] of "$ScriptPath:$lineNumber" (1-based), one per step
+          StepNames: string[] (or $null entries) of step names in the same order
+          TotalSteps: int count of steps
 
     .NOTES
         StepLines format matches Get-StepIdentifier output so callers can use IndexOf() to

--- a/Private/Get-StepLogConfig.ps1
+++ b/Private/Get-StepLogConfig.ps1
@@ -20,9 +20,9 @@ function Get-StepLogConfig {
 
     .OUTPUTS
         PSCustomObject with properties:
-          UniqueStaticLogPaths  — string[] of distinct resolved -LogPath values (may include '<dynamic>')
-          HasConflict           — bool; $true when UniqueStaticLogPaths.Count -gt 1
-          NoLogStepIds          — string[] of "ScriptPath:LineNumber" for -NoLog steps
+          UniqueStaticLogPaths: string[] of distinct resolved -LogPath values (may include '<dynamic>')
+          HasConflict: bool; $true when UniqueStaticLogPaths.Count -gt 1
+          NoLogStepIds: string[] of "ScriptPath:LineNumber" for -NoLog steps
     #>
     [CmdletBinding()]
     param(

--- a/Public/ConvertTo-StepperScript.ps1
+++ b/Public/ConvertTo-StepperScript.ps1
@@ -106,9 +106,9 @@ function ConvertTo-StepperScript {
             Write-Host "?"
             Write-Host ""
             Write-Host "  [Y] Yes (Default)" -ForegroundColor Cyan
-            Write-Host "  [n] No — skip this variable" -ForegroundColor White
-            Write-Host "  [a] All — convert all remaining candidates" -ForegroundColor White
-            Write-Host "  [q] Quit — stop conversion" -ForegroundColor White
+            Write-Host "  [n] No, skip this variable" -ForegroundColor White
+            Write-Host "  [a] All, convert all remaining candidates" -ForegroundColor White
+            Write-Host "  [q] Quit, stop conversion" -ForegroundColor White
             Write-Host ""
             Write-Host "Choice? [" -NoNewline
             Write-Host "Y" -NoNewline -ForegroundColor Cyan
@@ -183,7 +183,7 @@ function ConvertTo-StepperScript {
         }
     }
 
-    # Also collect occurrences in unmanaged (script-level) code — outside all step bodies.
+    # Also collect occurrences in unmanaged (script-level) code, outside all step bodies.
     # Variables assigned there and read in steps are candidates too, and their script-level
     # uses must be rewritten so they stay in sync with $Stepper.<Var>.
     $stepBodyRanges = $stepBodies | ForEach-Object {
@@ -247,7 +247,7 @@ function ConvertTo-StepperScript {
             '$StepperConversionComplete = $true' + $nl +
             $content.Substring($endRegionIndex)
     } else {
-        # No existing ignore region — create a new one before the first New-Step call
+        # No existing ignore region; create a new one before the first New-Step call
         $sentinelAst = [System.Management.Automation.Language.Parser]::ParseInput(
             $content, [ref]$null, [ref]$null
         )

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -63,7 +63,7 @@ function New-Step {
 
     .EXAMPLE
         New-Step {
-            Write-Host "Unnamed step — backward-compatible syntax."
+            Write-Host "Unnamed step. Backward-compatible syntax."
         }
 
     .NOTES
@@ -392,7 +392,7 @@ function New-Step {
             if ($conversionCandidates.Count -gt 0) {
                 ConvertTo-StepperScript -Path $scriptPath
                 if (Test-StepperConversionComplete -ScriptPath $scriptPath) {
-                    # Script was rewritten — tell user what happened and exit
+                    # Script was rewritten; tell user what happened and exit
                     $scriptName = Split-Path $scriptPath -Leaf
                     Write-Host ""
                     Write-Host "Cross-step variables have been converted to `$Stepper.<Var> notation and `$StepperConversionComplete = `$true has been added to $scriptName." -ForegroundColor Green
@@ -404,14 +404,14 @@ function New-Step {
 
         $existingState = Read-StepperState -StatePath $statePath
 
-        #Region Log config — resolve on fresh run, restore on resume
+        #Region Log config: resolve on fresh run, restore on resume
         if ($existingState -and $existingState.LogPath) {
-            # Resumed run — restore log config from state, no prompts
+            # Resumed run: restore log config from state, no prompts
             $executionState.LogPath        = $existingState.LogPath
             $executionState.LoggingEnabled = $existingState.LoggingEnabled
             $executionState.NoLogStepIds   = if ($existingState.NoLogStepIds) { @($existingState.NoLogStepIds) } else { @() }
         } else {
-            # Fresh run — scan AST and resolve
+            # Fresh run: scan AST and resolve
             $logConfig  = Get-StepLogConfig -ScriptPath $scriptPath
             $scriptDir  = Split-Path -Path $scriptPath -Parent
             $scriptName = Split-Path -Path $scriptPath -Leaf
@@ -473,7 +473,7 @@ function New-Step {
                 Write-Host ""
                 Write-Host "[i] Some steps have -NoLog specified: $noLogList" -ForegroundColor Cyan
                 Write-Host ""
-                Write-Host "  [A] Log all steps — ignore -NoLog flags (Default)" -ForegroundColor Cyan
+                Write-Host "  [A] Log all steps, ignore -NoLog flags (Default)" -ForegroundColor Cyan
                 Write-Host "  [s] Skip logging for those steps only" -ForegroundColor White
                 Write-Host "  [d] Disable logging entirely" -ForegroundColor White
                 Write-Host "  [q] Quit" -ForegroundColor White
@@ -501,7 +501,7 @@ function New-Step {
                         exit
                     }
                     default {
-                        # 'a' or anything else — log everything
+                        # 'a' or anything else: log everything
                     }
                 }
             }
@@ -526,7 +526,7 @@ function New-Step {
         if ($existingState) {
             # Check if script has been modified
             if ($existingState.ScriptHash -ne $currentHash) {
-                # Script has been modified since last run — prompt user for action
+                # Script has been modified since last run; prompt user for action
                 $inventory = Get-StepInventory -ScriptPath $scriptPath
                 $stepLines  = $inventory.StepLines
                 $stepNames  = $inventory.StepNames

--- a/Public/New-StepperScript.ps1
+++ b/Public/New-StepperScript.ps1
@@ -33,7 +33,7 @@ function New-StepperScript {
         Generate the full feature-showcase template instead of the minimal skeleton.
 
     .OUTPUTS
-        System.IO.FileInfo — the created file, suitable for pipeline use.
+        System.IO.FileInfo: the created file, suitable for pipeline use.
 
     .EXAMPLE
         New-StepperScript -Path './Deploy.ps1'

--- a/Public/Repair-StepperScript.ps1
+++ b/Public/Repair-StepperScript.ps1
@@ -7,14 +7,14 @@ function Repair-StepperScript {
         Calls Test-StepperScript internally to discover issues, then applies fixes for
         Error-severity and fixable Warning-severity issues:
 
-          MissingCmdletBinding  — inserts [CmdletBinding()] param() block
-          MissingInstallGuard   — inserts Install-Module Stepper guard after param()
-          MissingCbh            — delegates to Add-StepperCbh (silent)
+          MissingCmdletBinding  : inserts [CmdletBinding()] param() block
+          MissingInstallGuard   : inserts Install-Module Stepper guard after param()
+          MissingCbh            : delegates to Add-StepperCbh (silent)
 
         The following issues are reported via Write-Warning but NOT automatically fixed:
 
-          MissingStopStepper    — requires author decision on placement
-          NoSteps               — empty script structure is intentional or in-progress
+          MissingStopStepper    : requires author decision on placement
+          NoSteps               : empty script structure is intentional or in-progress
 
         Returns the post-fix result of Test-StepperScript. If no changes were needed,
         the script file is not touched.
@@ -25,7 +25,7 @@ function Repair-StepperScript {
         Absolute path to the PowerShell script file to repair.
 
     .OUTPUTS
-        PSCustomObject — the result of Test-StepperScript after repairs are applied.
+        PSCustomObject: the result of Test-StepperScript after repairs are applied.
                          Shape: { Path, IsValid, Issues[] }
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
@@ -100,7 +100,7 @@ function Repair-StepperScript {
                     $newLines += $scriptLines[$i]
                 }
             } else {
-                # [CmdletBinding()] exists but guard is missing — insert after param() block
+                # [CmdletBinding()] exists but guard is missing; insert after param() block
                 $guardInsertIndex = if ($parsedAst.Ast.ParamBlock) {
                     $parsedAst.Ast.ParamBlock.Extent.EndLineNumber
                 } else {

--- a/Public/Stop-Stepper.ps1
+++ b/Public/Stop-Stepper.ps1
@@ -84,7 +84,7 @@ function Stop-Stepper {
                     $logPath = $execState.Value.LogPath
                 }
             } catch {
-                # Ignore — log path optional
+                # Ignore; log path optional
             }
 
             $statePath = Get-StepperStatePath -ScriptPath $scriptPath

--- a/Public/Test-StepperScript.ps1
+++ b/Public/Test-StepperScript.ps1
@@ -9,11 +9,11 @@ function Test-StepperScript {
 
         Issue codes and their severities:
 
-          MissingCmdletBinding  (Error)   — [CmdletBinding()] not present
-          MissingInstallGuard   (Error)   — Install-Module Stepper guard absent
-          MissingCbh            (Warning) — No comment-based help block
-          MissingStopStepper    (Warning) — Stop-Stepper not called
-          NoSteps               (Warning) — No New-Step blocks found
+          MissingCmdletBinding  (Error)   : [CmdletBinding()] not present
+          MissingInstallGuard   (Error)   : Install-Module Stepper guard absent
+          MissingCbh            (Warning) : No comment-based help block
+          MissingStopStepper    (Warning) : Stop-Stepper not called
+          NoSteps               (Warning) : No New-Step blocks found
 
         IsValid is $true when no Error-severity issues are present (warnings are
         informational and do not affect overall validity).
@@ -23,9 +23,9 @@ function Test-StepperScript {
 
     .OUTPUTS
         PSCustomObject with properties:
-          Path     — Resolved path to the script
-          IsValid  — $true when no Error-severity issues exist
-          Issues   — Array of PSCustomObjects with Code, Severity, Message
+          Path     : Resolved path to the script
+          IsValid  : $true when no Error-severity issues exist
+          Issues   : Array of PSCustomObjects with Code, Severity, Message
     #>
     [CmdletBinding()]
     param(

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Stop-Stepper   # removes the state file on successful completion
 
 If the script fails inside a `New-Step` block, the next run resumes at the step that failed. All previously completed steps are skipped!
 
-On first run, Stepper checks for `[CmdletBinding()]` and the self-install guard independently — each is silently injected if missing (the guard is wrapped in `#region Stepper ignore` so it won't trigger unmanaged-code warnings), then Stepper exits and asks you to re-run. Nothing is required beyond what's shown above.
+On first run, Stepper checks for `[CmdletBinding()]` and the self-install guard independently. Each component is silently injected if missing (the guard is wrapped in `#region Stepper ignore` so it won't trigger unmanaged-code warnings), then Stepper exits and asks you to re-run. Nothing is required beyond what's shown above.
 
-Stepper also logs every step — execution timing, host output, and a per-step transcript — to `<scriptname>.ps1.stepper.log` by default. No configuration required.
+Stepper also logs every step's execution timing, host output, and a per-step transcript to `<scriptname>.ps1.stepper.log` by default. No configuration required.
 
 ---
 
@@ -65,12 +65,12 @@ Created with [VHS](https://github.com/charmbracelet/vhs) by [Charm](https://char
 
 ## Learn More
 
-- [How It Works](Docs/how-it-works.md) — execution lifecycle, resume logic, verbose output, non-interactive mode
-- [Named Steps](Docs/named-steps.md) — step names, `$Stepper.StepName`, resume prompt formats
-- [Data Persistence](Docs/data-persistence.md) — `$Stepper` hashtable, state file schema
-- [Logging](Docs/logging.md) — log files, step transcripts, `-LogPath`, `-NoLog`
-- [Unmanaged Code](Docs/unmanaged-code.md) — detection, `#region Stepper ignore`, interactive resolution
-- [API Reference](Docs/api-reference.md) — `New-Step`, `Stop-Stepper`, `New-StepperScript`, `Test-StepperScript`, `Repair-StepperScript`
+- [How It Works](Docs/how-it-works.md): execution lifecycle, resume logic, verbose output, non-interactive mode
+- [Named Steps](Docs/named-steps.md): step names, `$Stepper.StepName`, resume prompt formats
+- [Data Persistence](Docs/data-persistence.md): `$Stepper` hashtable, state file schema
+- [Logging](Docs/logging.md): log files, step transcripts, `-LogPath`, `-NoLog`
+- [Unmanaged Code](Docs/unmanaged-code.md): detection, `#region Stepper ignore`, interactive resolution
+- [API Reference](Docs/api-reference.md): `New-Step`, `Stop-Stepper`, `New-StepperScript`, `Test-StepperScript`, `Repair-StepperScript`, `ConvertTo-StepperScript`
 - [Examples](Docs/examples.md)
 - [Troubleshooting](Docs/troubleshooting.md)
 

--- a/Tests/Add-StepperCbh.Tests.ps1
+++ b/Tests/Add-StepperCbh.Tests.ps1
@@ -196,7 +196,7 @@ Describe 'Add-StepperCbh' -Tag 'Unit' {
             )
 
             try {
-                # Act / Assert — if exit is called Pester would catch an ExitException
+                # Act / Assert; if exit is called Pester would catch an ExitException
                 { Add-StepperCbh -ScriptPath $path } | Should -Not -Throw
             }
             finally {

--- a/Tests/ConvertTo-StepperScript.Tests.ps1
+++ b/Tests/ConvertTo-StepperScript.Tests.ps1
@@ -167,7 +167,7 @@ Describe 'ConvertTo-StepperScript' -Tag 'Unit' {
             try {
                 ConvertTo-StepperScript -Path $path -Force
                 $result = Get-Content -Path $path -Raw
-                # $servers is a cross-step candidate — all uses must be rewritten
+                # $servers is a cross-step candidate; all uses must be rewritten
                 $result | Should -Not -Match '(?<!\.)(\$servers)\b'
                 $result | Should -Match '\$Stepper\.Servers'
             }

--- a/Tests/New-Step.Tests.ps1
+++ b/Tests/New-Step.Tests.ps1
@@ -233,7 +233,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Resume logic — script unchanged' {
+    Context 'Resume logic: script unchanged' {
         BeforeEach {
             # Two-step script: step 1 was completed, step 2 should run on resume
             $script:ResumeInfo = New-TestStepperScript -BaseName "resume-$(New-Guid)" -StepCount 2
@@ -259,7 +259,7 @@ Describe 'New-Step' -Tag 'Integration' {
             Remove-Variable -Name '__StepperExecutionState' -ErrorAction SilentlyContinue
         }
 
-        It 'Skips step 1 (already completed) — state not updated for skipped step' {
+        It 'Skips step 1 (already completed): state not updated for skipped step' {
             # Call step 1 (should be skipped). The state file should NOT be updated
             # (no re-write for a skipped step). The pre-existing hash should still match.
             New-Step { }
@@ -289,7 +289,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Resume logic — Start over' {
+    Context 'Resume logic: Start over' {
         BeforeEach {
             $script:StartOverInfo = New-TestStepperScript -BaseName "startover-$(New-Guid)" -StepCount 2
             $step1Id = "$($script:StartOverInfo.Path):$($script:StartOverInfo.FirstStepLine)"
@@ -329,7 +329,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Resume logic — changed script defaults to Start over' {
+    Context 'Resume logic: changed script defaults to Start over' {
         BeforeEach {
             $script:ChangedInfo = New-TestStepperScript -BaseName "changed-$(New-Guid)" -StepCount 2
             $step1Id = "$($script:ChangedInfo.Path):$($script:ChangedInfo.FirstStepLine)"
@@ -369,7 +369,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Missing Stop-Stepper — user chooses A (add)' {
+    Context 'Missing Stop-Stepper: user chooses A (add)' {
         BeforeEach {
             # Script without Stop-Stepper
             $script:NoStopPath = Join-Path $TestDrive "nostop-$(New-Guid).ps1"
@@ -396,7 +396,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Missing Stop-Stepper — user chooses C (continue)' {
+    Context 'Missing Stop-Stepper: user chooses C (continue)' {
         BeforeEach {
             $script:NoStopContinuePath = Join-Path $TestDrive "nostop-c-$(New-Guid).ps1"
             Set-Content -Path $script:NoStopContinuePath -Value @(
@@ -421,7 +421,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — default log path' {
+    Context 'Logging: default log path' {
         BeforeEach {
             $script:LogDefaultInfo = New-TestStepperScript -BaseName 'log-default'
             Mock Get-StepIdentifier { "$($script:LogDefaultInfo.Path):$($script:LogDefaultInfo.FirstStepLine)" }
@@ -444,7 +444,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — explicit -LogPath parameter' {
+    Context 'Logging: explicit -LogPath parameter' {
         BeforeEach {
             $script:LogExplicitInfo = New-TestStepperScript -BaseName 'log-explicit'
             $script:ExplicitLogPath = Join-Path $TestDrive 'explicit.log'
@@ -462,7 +462,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — conflicting -LogPath values prompt user' {
+    Context 'Logging: conflicting -LogPath values prompt user' {
         BeforeEach {
             $script:ConflictInfo = New-TestStepperScript -BaseName 'log-conflict'
             Mock Get-StepIdentifier { "$($script:ConflictInfo.Path):$($script:ConflictInfo.FirstStepLine)" }
@@ -485,7 +485,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — runtime -LogPath mismatch writes warning' {
+    Context 'Logging: runtime -LogPath mismatch writes warning' {
         BeforeEach {
             $script:MismatchInfo = New-TestStepperScript -BaseName 'log-mismatch'
             $script:ResolvedLog = Join-Path $TestDrive 'resolved.log'
@@ -503,7 +503,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — active transcript causes hard stop' {
+    Context 'Logging: active transcript causes hard stop' {
         BeforeEach {
             $script:TranscriptInfo = New-TestStepperScript -BaseName 'log-transcript'
             Mock Get-StepIdentifier { "$($script:TranscriptInfo.Path):$($script:TranscriptInfo.FirstStepLine)" }
@@ -525,7 +525,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — transcript section in log file' {
+    Context 'Logging: transcript section in log file' {
         BeforeEach {
             $script:TranscriptLogInfo = New-TestStepperScript -BaseName 'log-transcript-section'
             $script:TranscriptLogPath = Join-Path $TestDrive 'transcript-test.log'
@@ -554,7 +554,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — failure writes ERROR entry to log' {
+    Context 'Logging: failure writes ERROR entry to log' {
         BeforeEach {
             $script:FailLogInfo = New-TestStepperScript -BaseName 'log-fail'
             $script:FailLogPath = Join-Path $TestDrive 'fail-test.log'
@@ -585,7 +585,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — skipped steps written to log on resume' {
+    Context 'Logging: skipped steps written to log on resume' {
         BeforeEach {
             $script:SkipLogInfo  = New-TestStepperScript -BaseName "log-skip-$(New-Guid)" -StepCount 2
             $script:SkipLogPath  = Join-Path $TestDrive 'skip-test.log'
@@ -612,8 +612,8 @@ Describe 'New-Step' -Tag 'Integration' {
         }
 
         It 'Should write a Skipping log entry for a previously completed step' {
-            New-Step { }   # step 1 — skipped (last completed)
-            New-Step { }   # step 2 — runs
+            New-Step { }   # step 1, skipped (last completed)
+            New-Step { }   # step 2, runs
             $logContent = Get-Content -Path $script:SkipLogPath -Raw -ErrorAction SilentlyContinue
             $logContent | Should -Match 'Skipping step \d+/\d+'
         }
@@ -655,7 +655,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — -NoLog step scope prompt' {
+    Context 'Logging: -NoLog step scope prompt' {
         BeforeEach {
             $script:NoLogInfo = New-TestStepperScript -BaseName 'log-nolog'
             Mock Get-StepIdentifier { "$($script:NoLogInfo.Path):$($script:NoLogInfo.FirstStepLine)" }
@@ -684,7 +684,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — disabled-step marker written to log' {
+    Context 'Logging: disabled-step marker written to log' {
         BeforeEach {
             $script:DisabledLogInfo = New-TestStepperScript -BaseName 'log-disabled'
             $script:DisabledLogPath = Join-Path $TestDrive 'disabled-step.log'
@@ -716,7 +716,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — step name included in log messages' {
+    Context 'Logging: step name included in log messages' {
         BeforeEach {
             $script:NamedLogInfo = New-TestStepperScript -BaseName 'log-named-step'
             $script:NamedLogPath = Join-Path $TestDrive 'named-step.log'
@@ -752,7 +752,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — skipped steps written to log on resume' {
+    Context 'Logging: skipped steps written to log on resume' {
         BeforeEach {
             $script:SkipLogInfo = New-TestStepperScript -BaseName "log-skip-$(New-Guid)" -StepCount 2
             $script:SkipLogPath = Join-Path $TestDrive 'skip-test.log'
@@ -793,7 +793,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — parameter validation' {
+    Context 'Retry: parameter validation' {
         BeforeEach {
             $script:RetryValInfo = New-TestStepperScript -BaseName "retry-val-$(New-Guid)"
             Mock Get-StepIdentifier { "$($script:RetryValInfo.Path):$($script:RetryValInfo.FirstStepLine)" }
@@ -821,7 +821,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — single-attempt behavior unchanged without -Retry' {
+    Context 'Retry: single-attempt behavior unchanged without -Retry' {
         BeforeEach {
             $script:NoRetryInfo = New-TestStepperScript -BaseName "no-retry-$(New-Guid)"
             Mock Get-StepIdentifier { "$($script:NoRetryInfo.Path):$($script:NoRetryInfo.FirstStepLine)" }
@@ -853,7 +853,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — success on first attempt does not trigger retry' {
+    Context 'Retry: success on first attempt does not trigger retry' {
         BeforeEach {
             $script:RetrySuccessInfo = New-TestStepperScript -BaseName "retry-ok-$(New-Guid)"
             Mock Get-StepIdentifier { "$($script:RetrySuccessInfo.Path):$($script:RetrySuccessInfo.FirstStepLine)" }
@@ -875,7 +875,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — step fails once then succeeds' {
+    Context 'Retry: step fails once then succeeds' {
         BeforeEach {
             $script:RetryOnceInfo = New-TestStepperScript -BaseName "retry-once-$(New-Guid)"
             Mock Get-StepIdentifier { "$($script:RetryOnceInfo.Path):$($script:RetryOnceInfo.FirstStepLine)" }
@@ -915,7 +915,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — all retries exhausted' {
+    Context 'Retry: all retries exhausted' {
         BeforeEach {
             $script:RetryExhaustedInfo = New-TestStepperScript -BaseName "retry-exhaust-$(New-Guid)"
             Mock Get-StepIdentifier { "$($script:RetryExhaustedInfo.Path):$($script:RetryExhaustedInfo.FirstStepLine)" }
@@ -962,7 +962,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — exponential backoff wait times' {
+    Context 'Retry: exponential backoff wait times' {
         BeforeEach {
             $script:RetryBackoffInfo = New-TestStepperScript -BaseName "retry-backoff-$(New-Guid)"
             Mock Get-StepIdentifier { "$($script:RetryBackoffInfo.Path):$($script:RetryBackoffInfo.FirstStepLine)" }
@@ -995,7 +995,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — events logged via Write-StepperLog' {
+    Context 'Retry: events logged via Write-StepperLog' {
         BeforeEach {
             $script:RetryLogInfo = New-TestStepperScript -BaseName "retry-log-$(New-Guid)"
             $script:RetryLogPath = Join-Path $TestDrive "retry-events-$(New-Guid).log"
@@ -1047,7 +1047,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — elapsed time reporting' {
+    Context 'Retry: elapsed time reporting' {
         BeforeEach {
             $script:RetryElapsedInfo = New-TestStepperScript -BaseName "retry-elapsed-$(New-Guid)"
             $script:RetryElapsedLogPath = Join-Path $TestDrive "retry-elapsed-$(New-Guid).log"
@@ -1085,7 +1085,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — partial transcript per failed attempt' {
+    Context 'Retry: partial transcript per failed attempt' {
         BeforeEach {
             $script:RetryTranscriptInfo = New-TestStepperScript -BaseName "retry-transcript-$(New-Guid)"
             $script:RetryTranscriptLogPath = Join-Path $TestDrive "retry-transcript-$(New-Guid).log"
@@ -1127,7 +1127,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — warning when RetryInterval or MaxRetries used without -Retry' {
+    Context 'Retry: warning when RetryInterval or MaxRetries used without -Retry' {
         BeforeEach {
             $script:RetryWarnInfo = New-TestStepperScript -BaseName "retry-warn-$(New-Guid)"
             Mock Get-StepIdentifier { "$($script:RetryWarnInfo.Path):$($script:RetryWarnInfo.FirstStepLine)" }
@@ -1159,7 +1159,7 @@ Describe 'New-Step' -Tag 'Integration' {
         }
     }
 
-    Context 'Retry — visual indicator on Write-Host' {
+    Context 'Retry: visual indicator on Write-Host' {
         BeforeEach {
             $script:VisualIndicatorInfo = New-TestStepperScript -BaseName "retry-visual-$(New-Guid)"
             Mock Get-StepIdentifier { "$($script:VisualIndicatorInfo.Path):$($script:VisualIndicatorInfo.FirstStepLine)" }

--- a/Tests/New-StepperBackup.Tests.ps1
+++ b/Tests/New-StepperBackup.Tests.ps1
@@ -54,7 +54,7 @@ Describe 'New-StepperBackup' {
 
     Context 'Overwrites an existing backup at the same timestamp' {
         It 'Should overwrite without error when backup already exists' {
-            # Call twice — second call should not throw
+            # Call twice; second call should not throw
             New-StepperBackup -Path $script:OrigPath
             { New-StepperBackup -Path $script:OrigPath } | Should -Not -Throw
         }

--- a/Tests/New-StepperScript.Tests.ps1
+++ b/Tests/New-StepperScript.Tests.ps1
@@ -200,7 +200,7 @@ Describe 'New-StepperScript' -Tag 'Unit' {
                 # Act
                 New-StepperScript -Path $path | Out-Null
                 $content = Get-Content -Path $path -Raw
-                # Assert — showcase-only content should not appear in minimal
+                # Assert; showcase-only content should not appear in minimal
                 $content | Should -Not -Match '\$Stepper\.'
             }
             finally { Remove-Item $path -ErrorAction SilentlyContinue }

--- a/Tests/Repair-StepperScript.Tests.ps1
+++ b/Tests/Repair-StepperScript.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Repair-StepperScript' -Tag 'Unit' {
             # Arrange
             $path = New-TempScript @('[CmdletBinding()]', 'param()', 'Stop-Stepper')
             try {
-                # Act / Assert — should not throw ParameterNotFound
+                # Act / Assert; should not throw ParameterNotFound
                 { Repair-StepperScript -Path $path } | Should -Not -Throw
             }
             finally { Remove-Item $path -ErrorAction SilentlyContinue }
@@ -51,7 +51,7 @@ Describe 'Repair-StepperScript' -Tag 'Unit' {
         }
 
         It 'Should return the post-fix Test-StepperScript result' {
-            # Arrange — script is missing CmdletBinding
+            # Arrange; script is missing CmdletBinding
             $path = New-TempScript @(
                 'param()'
                 'if (-not (Get-Module Stepper)) { Install-Module Stepper -Force }'
@@ -61,7 +61,7 @@ Describe 'Repair-StepperScript' -Tag 'Unit' {
             try {
                 # Act
                 $result = Repair-StepperScript -ScriptPath $path
-                # Assert — after repair, MissingCmdletBinding should be gone
+                # Assert; after repair, MissingCmdletBinding should be gone
                 $codes = $result.Issues | Select-Object -ExpandProperty Code
                 $codes | Should -Not -Contain 'MissingCmdletBinding'
             }
@@ -144,7 +144,7 @@ Describe 'Repair-StepperScript' -Tag 'Unit' {
                 # Act
                 $result = Repair-StepperScript -ScriptPath $path
                 $after  = Get-Content -Path $path -Raw
-                # Assert — file should not have Stop-Stepper injected by Repair
+                # Assert; file should not have Stop-Stepper injected by Repair
                 $after | Should -Not -Match 'Stop-Stepper'
                 # but the issue should still be in the result
                 $codes = $result.Issues | Select-Object -ExpandProperty Code
@@ -165,7 +165,7 @@ Describe 'Repair-StepperScript' -Tag 'Unit' {
                 # Act
                 $result = Repair-StepperScript -ScriptPath $path
                 $content = Get-Content -Path $path -Raw
-                # Assert — no actual New-Step { } call injected (CBH blurb may mention it)
+                # Assert; no actual New-Step { } call injected (CBH blurb may mention it)
                 $content | Should -Not -Match 'New-Step\s*\{'
                 $codes = $result.Issues | Select-Object -ExpandProperty Code
                 $codes | Should -Contain 'NoSteps'

--- a/Tests/Stop-Stepper.Tests.ps1
+++ b/Tests/Stop-Stepper.Tests.ps1
@@ -9,7 +9,7 @@ BeforeAll {
 
     # On macOS, $TestDrive resolves to /private/tmp/… which matches the
     # */Private/*.ps1 path filter in Stop-Stepper (case-insensitive -like).
-    # Use the test file's own path as the fake "user script" ScriptName — it
+    # Use the test file's own path as the fake "user script" ScriptName, it
     # lives in Tests/ and will never match Private/, Public/, or Stepper.psm1.
     $script:FakeUserScript = Join-Path $PSScriptRoot 'Stop-Stepper.Tests.ps1'
     $script:FakeStatePath  = Get-StepperStatePath -ScriptPath $script:FakeUserScript
@@ -146,7 +146,7 @@ Describe 'Stop-Stepper' -Tag 'Integration' {
             Write-StepperState -StatePath $script:FakeStatePath -ScriptHash 'abc' `
                 -LastCompletedStep "${script:FakeUserScript}:1"
 
-            # Return only module frames — forces fallback to __StepperExecutionState
+            # Return only module frames; forces fallback to __StepperExecutionState
             $sep = [System.IO.Path]::DirectorySeparatorChar
             $modulePath = $ModulePath
             $frames = @(
@@ -206,7 +206,7 @@ Describe 'Stop-Stepper' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — summary entry written on completion' {
+    Context 'Logging: summary entry written on completion' {
         BeforeEach {
             Write-StepperState -StatePath $script:FakeStatePath -ScriptHash 'abc123' `
                 -LastCompletedStep "${script:FakeUserScript}:1"
@@ -243,7 +243,7 @@ Describe 'Stop-Stepper' -Tag 'Integration' {
         }
     }
 
-    Context 'Logging — reads LogPath from execution state' {
+    Context 'Logging: reads LogPath from execution state' {
         BeforeEach {
             Write-StepperState -StatePath $script:FakeStatePath -ScriptHash 'abc123' `
                 -LastCompletedStep "${script:FakeUserScript}:1"

--- a/Tests/Test-StepperScript.Tests.ps1
+++ b/Tests/Test-StepperScript.Tests.ps1
@@ -76,7 +76,7 @@ Describe 'Test-StepperScript' -Tag 'Unit' {
             # Arrange
             $path = New-TempScript @('[CmdletBinding()]', 'param()', 'Stop-Stepper')
             try {
-                # Act / Assert — should not throw ParameterNotFound
+                # Act / Assert; should not throw ParameterNotFound
                 { Test-StepperScript -Path $path } | Should -Not -Throw
             }
             finally { Remove-Item $path -ErrorAction SilentlyContinue }

--- a/Tests/Write-StepperLog.Tests.ps1
+++ b/Tests/Write-StepperLog.Tests.ps1
@@ -56,7 +56,7 @@ Describe 'Write-StepperLog' -Tag 'Unit' {
         }
     }
 
-    Context 'File output — LogPath provided' {
+    Context 'File output: LogPath provided' {
         BeforeEach {
             $LogPath = Join-Path $TestDrive "stepper-$(New-Guid).log"
         }
@@ -96,7 +96,7 @@ Describe 'Write-StepperLog' -Tag 'Unit' {
         }
     }
 
-    Context 'File output — LogPath not provided' {
+    Context 'File output: LogPath not provided' {
         It 'Should not create any file when LogPath is omitted' {
             $dir = $TestDrive
             $before = (Get-ChildItem -Path $dir -Recurse).Count


### PR DESCRIPTION
## Summary

Documents the Phase 7 features shipped in #59 and sweeps em-dashes from all source, test, and doc files.

## Changes

### Documentation
- **api-reference.md**: added full `ConvertTo-StepperScript` section (parameters, detection rules, interactive dialog, sentinel variable, backup note); added `Retry Behavior` subsection under `New-Step` explaining local-variable reset and the `$Stepper.*` persistence pattern with a code example
- **how-it-works.md**: added ConvertTo hook as step 4 of the first-run sequence; fixed resume dialog option casing (`[r]`/`[S]` vs `[R]`/`[s]`) to match code; updated non-interactive defaults table with ConvertTo entry
- **logging.md**: fixed dialog option casing (`[s]`/`[d]`/`[q]`/`[A]`) to match code exactly
- **data-persistence.md**: corrected `LoggingEnabled` default row from `[N]` to `[d]`
- **unmanaged-code.md**: corrected prompt option letters to match code (`[W]`/`[m]`/`[d]`/`[i]`/`[q]`)
- **README.md**: added `ConvertTo-StepperScript` to the API Reference bullet list

### Em-dash sweep
Replaced all em-dashes (`—`) with context-appropriate punctuation across 43 files:
- `:` for label-to-description patterns (headings, CBH, list items)
- `;` for two independent clauses joined inline
- `,` for parenthetical asides and dialog option descriptions
- Files touched: `Public/`, `Private/`, `Tests/`, `Docs/adr/` (0001–0012), `Docs/plan/`
- Excluded: `AGENTS.md`, `CLAUDE.md`, `.beads/hooks/` (agent instruction / git hook files)

## Testing
No behavior changes. Existing Pester suite unchanged.