### PR TITLE
fix(convert): inject install guard + sentinel after param() block

### DIFF
--- a/Public/ConvertTo-StepperScript.ps1
+++ b/Public/ConvertTo-StepperScript.ps1
@@ -247,25 +247,27 @@ function ConvertTo-StepperScript {
             '$StepperConversionComplete = $true' + $nl +
             $content.Substring($endRegionIndex)
     } else {
-        # No existing ignore region; create a new one before the first New-Step call
+        # No existing ignore region; create install guard + sentinel after param() block
         $sentinelAst = [System.Management.Automation.Language.Parser]::ParseInput(
             $content, [ref]$null, [ref]$null
         )
-        $firstNewStep = @($sentinelAst.FindAll({
-            param($node)
-            $node -is [System.Management.Automation.Language.CommandAst] -and
-            $node.GetCommandName() -eq 'New-Step'
-        }, $true) | Sort-Object { $_.Extent.StartLineNumber }) | Select-Object -First 1
 
-        if ($firstNewStep) {
-            $insertOffset = $firstNewStep.Extent.StartOffset
-            $sentinel = '#region Stepper ignore' + $nl +
-                        '$StepperConversionComplete = $true' + $nl +
-                        '#endregion Stepper ignore' + $nl
-            $content = $content.Substring(0, $insertOffset) +
-                $sentinel +
-                $content.Substring($insertOffset)
+        $insertOffset = if ($sentinelAst.ParamBlock) {
+            $sentinelAst.ParamBlock.Extent.EndOffset
+        } else {
+            # No param block; insert before the first top-level statement
+            $firstStatement = @($sentinelAst.EndBlock.Statements) | Select-Object -First 1
+            if ($firstStatement) { $firstStatement.Extent.StartOffset } else { $content.Length }
         }
+
+        $installGuard = $nl +
+            '#region Stepper ignore' + $nl +
+            "if (-not (Get-Module -Name Stepper) -and -not (Get-Module -ListAvailable -Name Stepper)) { Install-Module Stepper -Force }" + $nl +
+            '$StepperConversionComplete = $true' + $nl +
+            '#endregion Stepper ignore' + $nl
+        $content = $content.Substring(0, $insertOffset) +
+            $installGuard +
+            $content.Substring($insertOffset)
     }
 
     if ($OutputPath) {

--- a/Stepper.psd1
+++ b/Stepper.psd1
@@ -6,9 +6,9 @@
     CompatiblePSEditions=@('Desktop',        'Core')
     Copyright='(c) 2025 - 2026 Jake Hildreth, Gilmour Technologies Ltd. All rights reserved.'
     Description='A cross-platform PowerShell utility module for creating resumable, step-by-step scripts with automatic state persistence.'
-    FunctionsToExport=@('ConvertTo-StepperScript', 'New-Step', 'New-StepperScript', 'Repair-StepperScript', 'Stop-Stepper', 'Test-StepperScript')
+    FunctionsToExport=@('ConvertTo-StepperScript',        'New-Step',        'New-StepperScript',        'Repair-StepperScript',        'Stop-Stepper',        'Test-StepperScript')
     GUID='2260142f-ef07-4749-a430-a2062efefbf6'
-    ModuleVersion='2026.5.20932'
+    ModuleVersion='2026.5.70453'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Tests/ConvertTo-StepperScript.Tests.ps1
+++ b/Tests/ConvertTo-StepperScript.Tests.ps1
@@ -284,18 +284,25 @@ Describe 'ConvertTo-StepperScript' -Tag 'Unit' {
     }
 
     Context 'Sentinel injection ($StepperConversionComplete)' {
-        It 'Should inject $StepperConversionComplete = $true before the first New-Step when no ignore region exists' {
+        It 'Should inject install guard + sentinel after param() when no ignore region exists' {
             $path = New-TempScript ($CrossStepScript -split [System.Environment]::NewLine)
             try {
                 ConvertTo-StepperScript -Path $path -Force
                 $result = Get-Content -Path $path -Raw
                 $result | Should -Match '\$StepperConversionComplete\s*=\s*\$true'
-                # sentinel must appear BEFORE the first New-Step
-                $sentinelIndex = $result.IndexOf('$StepperConversionComplete')
+                # install guard must also be present
+                $result | Should -Match 'Install-Module Stepper'
+                # sentinel must be inside the region (before #endregion)
+                $sentinelIndex  = $result.IndexOf('$StepperConversionComplete')
+                $endRegionIndex = $result.IndexOf('#endregion Stepper ignore')
+                $sentinelIndex | Should -BeLessThan $endRegionIndex
+                # sentinel must appear after param() and before New-Step
+                $paramIndex    = $result.IndexOf('param()')
                 $newStepIndex  = $result.IndexOf('New-Step')
+                $sentinelIndex | Should -BeGreaterThan $paramIndex
                 $sentinelIndex | Should -BeLessThan $newStepIndex
-                # should be wrapped in a region
-                $result | Should -Match '#region Stepper ignore'
+                # only one region block should exist
+                ([regex]::Matches($result, '#region Stepper ignore')).Count | Should -Be 1
             }
             finally {
                 Remove-Item $path -ErrorAction SilentlyContinue


### PR DESCRIPTION
## What

When `ConvertTo-StepperScript` runs on a script with no existing `#region Stepper ignore` block, it previously created a sentinel-only region immediately before the first `New-Step` call. This was inconsistent with how `Repair-StepperScript` places the install guard.

## Why

The `$StepperConversionComplete` sentinel should live inside the install guard region (which also handles `Install-Module Stepper`), and that region belongs after `param()` — not floating before `New-Step`.

## Changes

- `Public/ConvertTo-StepperScript.ps1`: rewrote the "no existing ignore region" branch to insert a full install guard block (`#region Stepper ignore` + `Install-Module` check + `$StepperConversionComplete = $true` + `#endregion`) after the `param()` block (or before the first statement if no `param()` exists)
- `Tests/ConvertTo-StepperScript.Tests.ps1`: updated the "no ignore region" sentinel test to assert install guard is present, sentinel is inside the region, sentinel appears after `param()` and before `New-Step`, and only one region block is created
- `Stepper.psd1`: CalVer bump via `Build-Module.ps1`

## Tests

18 passing / 0 failing / 0 skipped