### PR TITLE
feat(build): add prerelease support and artefact generation to Build-Module

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,6 +1,8 @@
 param (
-    # A CalVer string if you need to manually override the default yyyy.M.dHmm version string.
+    # A CalVer string if you need to manually override the default yyyy.M.dHHmm version string.
     [string]$CalVer,
+    # A prerelease tag to append to the module version (e.g., 'alpha', 'beta', 'rc1').
+    [string]$Prerelease,
     [switch]$PublishToPSGallery,
     [string]$PSGalleryAPIPath,
     [string]$PSGalleryAPIKey
@@ -17,6 +19,7 @@ if ($Host.Name -eq 'Visual Studio Code Host' -or
     Write-Host 'Re-invoking in a clean pwsh process to avoid PSScriptAnalyzer assembly conflict...'
     $passThrough = @('-NoProfile', '-File', $PSCommandPath)
     if ($CalVer) { $passThrough += '-CalVer'; $passThrough += $CalVer }
+    if ($Prerelease) { $passThrough += '-Prerelease'; $passThrough += $Prerelease }
     if ($PublishToPSGallery) { $passThrough += '-PublishToPSGallery' }
     if ($PSGalleryAPIPath) { $passThrough += '-PSGalleryAPIPath'; $passThrough += $PSGalleryAPIPath }
     if ($PSGalleryAPIKey) { $passThrough += '-PSGalleryAPIKey'; $passThrough += $PSGalleryAPIKey }
@@ -54,6 +57,9 @@ Build-Module -ModuleName 'Stepper' {
         Description            = 'A cross-platform PowerShell utility module for creating resumable, step-by-step scripts with automatic state persistence.'
         PowerShellVersion      = '5.1'
         Tags                   = @('Windows', 'MacOS', 'Linux')
+    }
+    if ($Prerelease) {
+        $Manifest['Prerelease'] = $Prerelease
     }
     New-ConfigurationManifest @Manifest
 
@@ -121,8 +127,8 @@ Build-Module -ModuleName 'Stepper' {
 
     New-ConfigurationBuild -Enable:$true -SignModule:$false -DeleteTargetModuleBeforeBuild -MergeModuleOnBuild -MergeFunctionsFromApprovedModules -DoNotAttemptToFixRelativePaths
 
-    #New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked" #-RequiredModulesPath "$PSScriptRoot\..\Artefacts\Modules"
-    #New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -IncludeTagName
+    New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked"
+    New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -IncludeTagName
 
     # global options for publishing to github/psgallery
     if($PublishToPSGallery) {


### PR DESCRIPTION
Aligns `Build/Build-Module.ps1` with the Locksmith2/Deck pattern for prerelease builds and build artefact output.

## Changes

- **`$Prerelease` parameter** — new string param accepting a tag (e.g. `'pre'`, `'alpha'`, `'rc1'`) to stamp non-release builds
- **Clean-pwsh passthrough** — `-Prerelease` is forwarded through the VS Code host re-invocation block so the param survives the child process spawn
- **Manifest injection** — `$Manifest['Prerelease'] = $Prerelease` is set before `New-ConfigurationManifest` so the built PSD1 carries the correct prerelease tag
- **Artefact generation** — `New-ConfigurationArtefact` for Unpacked and Packed outputs is now enabled (was commented out), writing to `../Artefacts/Unpacked` and `../Artefacts/Packed`
- **CalVer comment fix** — corrected format string in comment from `yyyy.M.dHmm` to `yyyy.M.dHHmm`