### PR TITLE
feat(transcript): use minimal transcript header in step logs

### DIFF
--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -920,7 +920,7 @@ function New-Step {
 
             if ($stepLoggingEnabled -and $stepLogPath) {
                 $tempTranscript = [System.IO.Path]::GetTempFileName()
-                Start-Transcript -Path $tempTranscript -Force | Out-Null
+                Start-Transcript -Path $tempTranscript -Force -UseMinimalHeader -IncludeInvocationHeader | Out-Null
                 $transcriptStarted = $true
             }
 

--- a/Stepper.psd1
+++ b/Stepper.psd1
@@ -8,7 +8,7 @@
     Description='A cross-platform PowerShell utility module for creating resumable, step-by-step scripts with automatic state persistence.'
     FunctionsToExport=@('ConvertTo-StepperScript',        'New-Step',        'New-StepperScript',        'Repair-StepperScript',        'Stop-Stepper',        'Test-StepperScript')
     GUID='2260142f-ef07-4749-a430-a2062efefbf6'
-    ModuleVersion='2026.5.70453'
+    ModuleVersion='2026.5.300759'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{


### PR DESCRIPTION
## Summary

Reduces noise in step log transcripts by passing `-UseMinimalHeader` and `-IncludeInvocationHeader` to `Start-Transcript` in `New-Step`.

## Changes

- `Public/New-Step.ps1` — add `-UseMinimalHeader -IncludeInvocationHeader` to the `Start-Transcript` call inside the step logging block
- `Stepper.psd1` — version bump to `2026.5.300759`

## Why

The default `Start-Transcript` header includes verbose system/environment info that clutters step log output. `-UseMinimalHeader` suppresses that; `-IncludeInvocationHeader` keeps the per-command invocation lines, which are still useful for debugging.