### PR TITLE
fix: resolve PowerShell provider paths before .NET API calls in Test, Repair, and ConvertTo functions

### DIFF
--- a/Docs/adr/0013-isvalid-severity-threshold.md
+++ b/Docs/adr/0013-isvalid-severity-threshold.md
@@ -1,0 +1,31 @@
+# ADR 0013: IsValid reflects Error-severity issues only
+
+**Date:** 2026-05-30
+**Status:** Accepted
+**Deciders:** Jake Hildreth
+
+---
+
+## Context
+
+`Test-StepperScript` returns a `PSCustomObject` with an `IsValid` boolean and an `Issues` array. Issues have two severity levels:
+
+- `Error` — `MissingCmdletBinding`, `MissingInstallGuard`
+- `Warning` — `MissingCbh`, `MissingStopStepper`, `NoSteps`
+
+The question arose: should `IsValid` be `$false` when `Stop-Stepper` is missing?
+
+---
+
+## Decision
+
+`IsValid = $true` when no `Error`-severity issues are present. `Warning`-severity issues do not affect `IsValid`.
+
+---
+
+## Rationale
+
+- a missing `Stop-Stepper` will not cause Stepper to fail or behave incorrectly at runtime — it only means the state file is not cleaned up after a successful run, which is recoverable and cosmetic
+- `MissingCmdletBinding` and `MissingInstallGuard` are true blockers: without them the script cannot use `-WhatIf`/common parameters and will not self-install Stepper on a clean machine
+- `IsValid` is used by `New-Step` at first-run to decide whether `Repair-StepperScript` needs to run; including warnings in that gate would trigger unnecessary repairs on valid scripts
+- consumers who want stricter validation can inspect `Issues` directly and filter by `Severity`

--- a/Public/ConvertTo-StepperScript.ps1
+++ b/Public/ConvertTo-StepperScript.ps1
@@ -62,7 +62,7 @@ function ConvertTo-StepperScript {
         $scriptName = if ($Name -match '\.ps1$') { $Name } else { "$Name.ps1" }
         $resolvedPath = Join-Path $Directory $scriptName
     } else {
-        $resolvedPath = $Path
+        $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
     }
 
     if (-not (Test-Path -LiteralPath $resolvedPath)) {

--- a/Public/Repair-StepperScript.ps1
+++ b/Public/Repair-StepperScript.ps1
@@ -36,6 +36,8 @@ function Repair-StepperScript {
         [string]$ScriptPath
     )
 
+    $ScriptPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ScriptPath)
+
     $initialResult = Test-StepperScript -ScriptPath $ScriptPath
 
     $needsFix = $initialResult.Issues | Where-Object {

--- a/Public/Test-StepperScript.ps1
+++ b/Public/Test-StepperScript.ps1
@@ -35,6 +35,8 @@ function Test-StepperScript {
         [string]$ScriptPath
     )
 
+    $ScriptPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ScriptPath)
+
     $issues = [System.Collections.Generic.List[PSCustomObject]]::new()
 
     # Read script content

--- a/Stepper.psd1
+++ b/Stepper.psd1
@@ -8,7 +8,7 @@
     Description='A cross-platform PowerShell utility module for creating resumable, step-by-step scripts with automatic state persistence.'
     FunctionsToExport=@('ConvertTo-StepperScript',        'New-Step',        'New-StepperScript',        'Repair-StepperScript',        'Stop-Stepper',        'Test-StepperScript')
     GUID='2260142f-ef07-4749-a430-a2062efefbf6'
-    ModuleVersion='2026.5.70453'
+    ModuleVersion='2026.5.300850'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Tests/ConvertTo-StepperScript.Tests.ps1
+++ b/Tests/ConvertTo-StepperScript.Tests.ps1
@@ -367,4 +367,38 @@ Describe 'ConvertTo-StepperScript' -Tag 'Unit' {
             finally { Remove-Item $path -ErrorAction SilentlyContinue }
         }
     }
+
+    Context 'Path resolution' {
+        It 'Should accept a relative path (./script.ps1)' {
+            # Arrange - use a script with no cross-step candidates so no modification occurs
+            $path = New-TempScript ($NoCanidatesScript -split [System.Environment]::NewLine)
+            $dir  = Split-Path -Parent $path
+            $file = Split-Path -Leaf $path
+            Push-Location $dir
+            try {
+                # Act / Assert - should not throw
+                { ConvertTo-StepperScript -Path "./$file" } | Should -Not -Throw
+            }
+            finally {
+                Pop-Location
+                Remove-Item $path -ErrorAction SilentlyContinue
+                Remove-TempBaks $path
+            }
+        }
+
+        It 'Should accept a tilde path (~/script.ps1)' {
+            # Arrange
+            $fileName = "StepperPathTest_$([System.Guid]::NewGuid().ToString('N').Substring(0, 8)).ps1"
+            $absPath  = Join-Path $HOME $fileName
+            $NoCanidatesScript | Set-Content -Path $absPath -Encoding UTF8 -NoNewline
+            try {
+                # Act / Assert - should not throw
+                { ConvertTo-StepperScript -Path "~/$fileName" } | Should -Not -Throw
+            }
+            finally {
+                Remove-Item $absPath -ErrorAction SilentlyContinue
+                Remove-TempBaks $absPath
+            }
+        }
+    }
 }

--- a/Tests/Repair-StepperScript.Tests.ps1
+++ b/Tests/Repair-StepperScript.Tests.ps1
@@ -224,4 +224,52 @@ Describe 'Repair-StepperScript' -Tag 'Unit' {
             finally { Remove-Item $path -ErrorAction SilentlyContinue }
         }
     }
+
+    Context 'Path resolution' {
+        It 'Should accept a relative path (./script.ps1)' {
+            # Arrange
+            $path = New-TempScript @(
+                '[CmdletBinding()]'
+                'param()'
+                'if (-not (Get-Module -Name Stepper) -and -not (Get-Module -ListAvailable -Name Stepper)) { Install-Module Stepper -Force }'
+                'New-Step { Write-Host "step 1" }'
+                'Stop-Stepper'
+            )
+            $dir  = Split-Path -Parent $path
+            $file = Split-Path -Leaf $path
+            Push-Location $dir
+            try {
+                # Act
+                $result = Repair-StepperScript -ScriptPath "./$file"
+                # Assert - IsValid should be true; broken AST would cause false MissingCmdletBinding
+                $result.IsValid | Should -BeTrue
+            }
+            finally {
+                Pop-Location
+                Remove-Item $path -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Should accept a tilde path (~/script.ps1)' {
+            # Arrange
+            $fileName = "StepperPathTest_$([System.Guid]::NewGuid().ToString('N').Substring(0, 8)).ps1"
+            $absPath  = Join-Path $HOME $fileName
+            @(
+                '[CmdletBinding()]'
+                'param()'
+                'if (-not (Get-Module -Name Stepper) -and -not (Get-Module -ListAvailable -Name Stepper)) { Install-Module Stepper -Force }'
+                'New-Step { Write-Host "step 1" }'
+                'Stop-Stepper'
+            ) -join [System.Environment]::NewLine | Set-Content -Path $absPath -Encoding UTF8 -NoNewline
+            try {
+                # Act
+                $result = Repair-StepperScript -ScriptPath "~/$fileName"
+                # Assert - IsValid should be true; broken AST would cause false MissingCmdletBinding
+                $result.IsValid | Should -BeTrue
+            }
+            finally {
+                Remove-Item $absPath -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }

--- a/Tests/Test-StepperScript.Tests.ps1
+++ b/Tests/Test-StepperScript.Tests.ps1
@@ -385,4 +385,40 @@ Describe 'Test-StepperScript' -Tag 'Unit' {
             finally { Remove-Item $path -ErrorAction SilentlyContinue }
         }
     }
+
+    Context 'Path resolution' {
+        It 'Should accept a relative path (./script.ps1)' {
+            # Arrange
+            $path = New-TempScript ($ValidScript -split [System.Environment]::NewLine)
+            $dir  = Split-Path -Parent $path
+            $file = Split-Path -Leaf $path
+            Push-Location $dir
+            try {
+                # Act
+                $result = Test-StepperScript -ScriptPath "./$file"
+                # Assert
+                $result.IsValid | Should -BeTrue
+            }
+            finally {
+                Pop-Location
+                Remove-Item $path -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Should accept a tilde path (~/script.ps1)' {
+            # Arrange
+            $fileName = "StepperPathTest_$([System.Guid]::NewGuid().ToString('N').Substring(0, 8)).ps1"
+            $absPath  = Join-Path $HOME $fileName
+            $ValidScript | Set-Content -Path $absPath -Encoding UTF8 -NoNewline
+            try {
+                # Act
+                $result = Test-StepperScript -ScriptPath "~/$fileName"
+                # Assert
+                $result.IsValid | Should -BeTrue
+            }
+            finally {
+                Remove-Item $absPath -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`Test-StepperScript`, `Repair-StepperScript`, and `ConvertTo-StepperScript` all pass the caller-supplied path directly to `[System.Management.Automation.Language.Parser]::ParseFile()` (via `Get-ScriptAst`). That API uses the .NET working directory — not the PowerShell provider — so it silently fails to find the file when given:

- a relative path (`./script.ps1`) if PS CWD != .NET CWD
- a tilde path (`~/script.ps1`) on any platform

The result is an empty AST, which causes false `MissingCmdletBinding`, `NoSteps`, and `MissingStopStepper` issues on scripts that are perfectly valid.

## Fix

Resolve the path through PowerShell's provider at the entry point of each affected public function:

```powershell
$ScriptPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ScriptPath)