### PR TITLE
fix(resume): make Start Over pristine — no stale data from previous runs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,5 @@ feat(detection): add ESC6 detection for CA EDITF_ATTRIBUTESUBJECTALTNAME2 flag
 ```
 
 - Keep commits atomic and focused
-- Update CHANGELOG.MD for user-facing changes
 - Be specific about what changed and why
 

--- a/Docs/how-it-works.md
+++ b/Docs/how-it-works.md
@@ -35,7 +35,7 @@ If the hash doesn't match, Stepper warns about the inconsistency and prompts:
 [r] Resume (risky)   [S] Start over (default)   [m] More details   [q] Quit
 ```
 
-Start over removes the state file and runs fresh.
+Start over is a pristine fresh start: it removes the state file, clears the `$Stepper` variable from your session, and discards the previous run's logging choices (log path, logging on/off, and any `-NoLog` decisions), so the new run re-resolves logging from scratch. No data from the previous run carries over.
 
 ## More Details View
 

--- a/Private/Clear-StepperSession.ps1
+++ b/Private/Clear-StepperSession.ps1
@@ -1,0 +1,59 @@
+function Clear-StepperSession {
+    <#
+    .SYNOPSIS
+        Resets all Stepper session state for a pristine fresh start.
+
+    .DESCRIPTION
+        Removes the $Stepper variable from the caller's scope (so a new run
+        starts with no data from any previous run), clears a stale
+        __StepperInitialized sentinel so the next New-Step call runs the
+        first-run block, deletes the state file, and returns the execution
+        state to fresh-run defaults so no log config from a previous run
+        carries over.
+
+        Called by every fresh-start branch in New-Step (all Start Over menu
+        choices and the automatic fresh start after all steps complete).
+
+    .PARAMETER StatePath
+        The path to the state file to delete.
+
+    .PARAMETER CallingScope
+        The caller's session state (pass $PSCmdlet.SessionState from the
+        calling advanced function).
+
+    .PARAMETER ExecutionState
+        The live execution state hashtable to reset to fresh-run defaults.
+
+    .OUTPUTS
+        None
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$StatePath,
+
+        [Parameter(Mandatory)]
+        [System.Management.Automation.SessionState]$CallingScope,
+
+        [Parameter(Mandatory)]
+        [hashtable]$ExecutionState
+    )
+
+    # Remove $Stepper so no data from a previous run survives, regardless of
+    # how it got into the caller's scope
+    try {
+        $CallingScope.PSVariable.Remove('Stepper')
+    } catch {
+        # Best effort: New-Step recreates $Stepper on the next step
+    }
+
+    # Reset execution state to fresh-run defaults: no resume, no inherited log config
+    $ExecutionState.RestoreMode    = $false
+    $ExecutionState.TargetStep     = $null
+    $ExecutionState.LogPath        = $null
+    $ExecutionState.LoggingEnabled = $true
+    $ExecutionState.NoLogStepIds   = @()
+
+    # Delete the state file
+    Remove-StepperState -StatePath $StatePath
+}

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -11,6 +11,10 @@ function New-Step {
         The script content is hashed to detect modifications. If the script changes
         between runs, the state is invalidated and execution starts fresh.
 
+        Choosing Start Over is pristine: the state file is deleted, $Stepper is
+        removed from the caller's scope, and the previous run's log config is
+        discarded, so the new run behaves as if no prior run happened.
+
     .PARAMETER Name
         Optional name for this step. Displayed in verbose output and resume prompts.
 
@@ -404,8 +408,9 @@ function New-Step {
 
         $existingState = Read-StepperState -StatePath $statePath
 
-        #Region Log config: resolve on fresh run, restore on resume
-        if ($existingState -and $existingState.LogPath) {
+        #Region Log config: restore only on an actual resume; resolve fresh otherwise
+        # (Start Over branches set StartFresh, so a fresh run never inherits the old log config)
+        if ($existingState -and $existingState.LogPath -and -not $executionState.StartFresh) {
             # Resumed run: restore log config from state, no prompts
             $executionState.LogPath        = $existingState.LogPath
             $executionState.LoggingEnabled = $existingState.LoggingEnabled
@@ -512,16 +517,8 @@ function New-Step {
         }
         #EndRegion Log config
 
-        # Try to load persisted $Stepper data from state
-        if ($existingState -and $existingState.StepperData) {
-            try {
-                $callingScope.PSVariable.Set('Stepper', $existingState.StepperData)
-                $variableNames = ($existingState.StepperData.Keys | Sort-Object) -join ', '
-                Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Loaded `$Stepper data from disk ($variableNames)"
-            } catch {
-                Write-Warning "Failed to load persisted `$Stepper data: $_"
-            }
-        }
+        # NOTE: persisted $Stepper data is NOT injected here. It is injected only
+        # when the user chooses Resume, so a Start Over run never sees it.
 
         if ($existingState) {
             # Check if script has been modified
@@ -552,6 +549,8 @@ function New-Step {
                 $lastStepDisplay = if ($existingState.LastCompletedStepName) { "$($existingState.LastCompletedStepName) (Step $($lastStepIndex + 1), Line $lastStepLine)" } else { "Step $($lastStepIndex + 1) (Line $lastStepLine)" }
 
                 while ($true) {
+                    # A previous loop iteration already chose Start Over (state file deleted)
+                    if ($executionState.StartFresh -and -not (Test-Path -LiteralPath $statePath)) { break }
                     Write-Host ""
                     Write-Host "[!] Incomplete script run detected, but $scriptName has been modified." -ForegroundColor Magenta
                     Write-Host ""
@@ -584,14 +583,19 @@ function New-Step {
 
                     if ($response -eq '' -or $response -eq 'S' -or $response -eq 's') {
                         Write-Host "Starting fresh..." -ForegroundColor Yellow
-                        Remove-StepperState -StatePath $statePath
-                        break
+                        $executionState.StartFresh = $true
+                        Clear-StepperSession -StatePath $statePath -CallingScope $callingScope -ExecutionState $executionState
+                        continue
                     }
                     elseif ($response -eq 'R' -or $response -eq 'r') {
                         Write-Host ""
                         Write-Host "Resuming from $nextStepDisplay..." -ForegroundColor Green
                         $executionState.RestoreMode = $true
                         $executionState.TargetStep = $lastStep
+                        if ($existingState.StepperData) {
+                            $callingScope.PSVariable.Set('Stepper', $existingState.StepperData)
+                            Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Loaded `$Stepper data from disk"
+                        }
                         break
                     }
                     elseif ($response -eq 'M' -or $response -eq 'm') {
@@ -614,14 +618,19 @@ function New-Step {
 
                         if ($moreResponse -eq '' -or $moreResponse -eq 'S' -or $moreResponse -eq 's') {
                             Write-Host "Starting fresh..." -ForegroundColor Yellow
-                            Remove-StepperState -StatePath $statePath
-                            break
+                            $executionState.StartFresh = $true
+                            Clear-StepperSession -StatePath $statePath -CallingScope $callingScope -ExecutionState $executionState
+                            continue
                         }
                         elseif ($moreResponse -eq 'R' -or $moreResponse -eq 'r') {
                             Write-Host ""
                             Write-Host "Resuming from $nextStepDisplay..." -ForegroundColor Green
                             $executionState.RestoreMode = $true
                             $executionState.TargetStep = $lastStep
+                            if ($existingState.StepperData) {
+                                $callingScope.PSVariable.Set('Stepper', $existingState.StepperData)
+                                Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Loaded `$Stepper data from disk"
+                            }
                             break
                         }
                         elseif ($moreResponse -eq 'Q' -or $moreResponse -eq 'q') {
@@ -632,8 +641,9 @@ function New-Step {
                         else {
                             # Default to Start over for invalid input
                             Write-Host "Starting fresh..." -ForegroundColor Yellow
-                            Remove-StepperState -StatePath $statePath
-                            break
+                            $executionState.StartFresh = $true
+                            Clear-StepperSession -StatePath $statePath -CallingScope $callingScope -ExecutionState $executionState
+                            continue
                         }
                     }
                     elseif ($response -eq 'Q' -or $response -eq 'q') {
@@ -644,8 +654,9 @@ function New-Step {
                     else {
                         # Default to Start over for invalid input
                         Write-Host "Starting fresh..." -ForegroundColor Yellow
-                        Remove-StepperState -StatePath $statePath
-                        break
+                        $executionState.StartFresh = $true
+                        Clear-StepperSession -StatePath $statePath -CallingScope $callingScope -ExecutionState $executionState
+                        continue
                     }
                 }
             }
@@ -692,6 +703,8 @@ function New-Step {
                     $nextStepDisplay = if ($nextStepName) { "$nextStepName (Step $nextStepNumber, Line $nextStepLine)" } else { "Step $nextStepNumber (Line $nextStepLine)" }
 
                     while ($true) {
+                        # A previous loop iteration already chose Start Over (state file deleted)
+                        if ($executionState.StartFresh -and -not (Test-Path -LiteralPath $statePath)) { break }
                         Write-Host "How would you like to proceed?"
                         Write-Host ""
                         Write-Host "  [R] Resume $scriptName from $nextStepDisplay (Default)" -ForegroundColor Cyan
@@ -720,8 +733,9 @@ function New-Step {
                         }
                         elseif ($response -eq 'S' -or $response -eq 's') {
                             Write-Host "Starting fresh..." -ForegroundColor Yellow
-                            Remove-StepperState -StatePath $statePath
-                            break
+                            $executionState.StartFresh = $true
+                            Clear-StepperSession -StatePath $statePath -CallingScope $callingScope -ExecutionState $executionState
+                            continue
                         }
                         elseif ($response -eq 'M' -or $response -eq 'm') {
                             Show-MoreDetails -ExistingState $existingState -ScriptPath $scriptPath -CurrentHash $currentHash -LastStep $lastStep -NextStepLine $nextStepLine -NextStepName $nextStepName -NextStepNumber $nextStepNumber
@@ -743,14 +757,19 @@ function New-Step {
 
                             if ($moreResponse -eq '' -or $moreResponse -eq 'S' -or $moreResponse -eq 's') {
                                 Write-Host "Starting fresh..." -ForegroundColor Yellow
-                                Remove-StepperState -StatePath $statePath
-                                break
+                                $executionState.StartFresh = $true
+                                Clear-StepperSession -StatePath $statePath -CallingScope $callingScope -ExecutionState $executionState
+                                continue
                             }
                             elseif ($moreResponse -eq 'R' -or $moreResponse -eq 'r') {
                                 Write-Host ""
                                 Write-Host "Resuming from $nextStepDisplay..." -ForegroundColor Green
                                 $executionState.RestoreMode = $true
                                 $executionState.TargetStep = $lastStep
+                                if ($existingState.StepperData) {
+                                    $callingScope.PSVariable.Set('Stepper', $existingState.StepperData)
+                                    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Loaded `$Stepper data from disk"
+                                }
                                 break
                             }
                             elseif ($moreResponse -eq 'Q' -or $moreResponse -eq 'q') {
@@ -761,8 +780,9 @@ function New-Step {
                             else {
                                 # Default to Start over for invalid input
                                 Write-Host "Starting fresh..." -ForegroundColor Yellow
-                                Remove-StepperState -StatePath $statePath
-                                break
+                                $executionState.StartFresh = $true
+                                Clear-StepperSession -StatePath $statePath -CallingScope $callingScope -ExecutionState $executionState
+                                continue
                             }
                         }
                         elseif ($response -eq 'Q' -or $response -eq 'q') {
@@ -776,12 +796,18 @@ function New-Step {
                             Write-Host "Resuming from $nextStepDisplay..." -ForegroundColor Green
                             $executionState.RestoreMode = $true
                             $executionState.TargetStep = $lastStep
+                            if ($existingState.StepperData) {
+                                $callingScope.PSVariable.Set('Stepper', $existingState.StepperData)
+                                Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Loaded `$Stepper data from disk"
+                            }
                             break
                         }
                     }
                 } else {
                     Write-Host "All steps were completed. Starting fresh..." -ForegroundColor Yellow
-                    Remove-StepperState -StatePath $statePath
+                    $executionState.StartFresh = $true
+                    Clear-StepperSession -StatePath $statePath -CallingScope $callingScope -ExecutionState $executionState
+                    continue
                 }
                 Write-Host ""
             }

--- a/Tests/New-Step.Tests.ps1
+++ b/Tests/New-Step.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
     . "$ModulePath/Private/Write-StepperState.ps1"
     . "$ModulePath/Private/Read-StepperState.ps1"
     . "$ModulePath/Private/Remove-StepperState.ps1"
+    . "$ModulePath/Private/Clear-StepperSession.ps1"
     . "$ModulePath/Private/Test-LineInIgnoredRegion.ps1"
     . "$ModulePath/Private/Find-NewStepBlocks.ps1"
     . "$ModulePath/Private/Get-StepInventory.ps1"
@@ -366,6 +367,62 @@ Describe 'New-Step' -Tag 'Integration' {
             $sideEffect = Join-Path $TestDrive "changed-side-$(New-Guid).txt"
             New-Step { Set-Content -Path $sideEffect -Value 'ran' }
             $sideEffect | Should -Exist
+        }
+    }
+
+    Context 'Pristine Start Over' {
+        BeforeEach {
+            Remove-Variable -Name 'Stepper' -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperInitialized' -ErrorAction SilentlyContinue
+            Remove-Variable -Name '__StepperExecutionState' -ErrorAction SilentlyContinue
+        }
+
+        It 'Start Over does not reuse data from previous runs' {
+            $info = New-TestStepperScript -BaseName "pristine-$(New-Guid)" -StepCount 2
+            $step1Id = "$($info.Path):$($info.FirstStepLine)"
+            $step2Id = "$($info.Path):$($info.FirstStepLine + 1)"
+            Write-StepperState -StatePath $info.StatePath `
+                -ScriptHash (Get-ScriptHash -ScriptPath $info.Path) `
+                -LastCompletedStep $step1Id `
+                -StepNumber 1 `
+                -StepperData @{ PriorRunSecret = 'stale' } `
+                -LogPath (Join-Path $TestDrive 'old.log') `
+                -LoggingEnabled $true `
+                -NoLogStepIds @($step2Id)
+
+            # Stale session variable: same-console rerun left data behind
+            $Stepper = @{ PriorRunSecret = 'stale' }
+
+            $script:PristineCallCount = 0
+            Mock Get-StepIdentifier {
+                $script:PristineCallCount++
+                if ($script:PristineCallCount -eq 1) { $step1Id } else { $step2Id }
+            }
+            Mock Read-Host { 'S' }
+
+            New-Step { }
+
+            # The stale $Stepper was removed from the caller's scope: it is no
+            # longer visible here (the leak path is closed). New-Step recreates
+            # an empty one internally for state persistence.
+            $stepperVar = Get-Variable -Name 'Stepper' -ValueOnly -ErrorAction SilentlyContinue
+            $stepperVar | Should -BeNullOrEmpty
+
+            # Execution state is fresh, not resumed from the prior run
+            $execState = Get-Variable -Name '__StepperExecutionState' -ValueOnly
+            $execState.RestoreMode | Should -BeFalse
+            $execState.TargetStep | Should -BeNullOrEmpty
+            $execState.LogPath | Should -Not -Be (Join-Path $TestDrive 'old.log')
+            $execState.NoLogStepIds | Should -Not -Contain $step2Id
+
+            New-Step { }
+
+            # The re-persistence mechanism is dead: new state carries no prior data
+            $state = Import-Clixml -Path $info.StatePath
+            $state.LastCompletedStep | Should -Be $step2Id
+            if ($state.StepperData) {
+                $state.StepperData.Keys | Should -Not -Contain 'PriorRunSecret'
+            }
         }
     }
 


### PR DESCRIPTION
## What

Fixes the user-reported bug where choosing **Start Over** at the resume prompt reused data stored in the `.stepper` file from previous runs.

## Root cause

`New-Step` injected the persisted `$Stepper` data into the caller's scope **before** showing the resume prompt, and every Start Over branch only deleted the state file. The stale `$Stepper` stayed live, so when the first step of the "fresh" run completed, `Write-StepperState` wrote the old data back into the new state file — the bug self-perpetuated. Log config (`LogPath`/`LoggingEnabled`/`NoLogStepIds`) also silently carried over.

Investigated and specified via the wayfinder map in #69 (root cause #71, design #72, test strategy #73).

## The fix

- **New `Private/Clear-StepperSession.ps1`** — owns the pristine guarantee: removes `$Stepper` from the caller's scope, resets execution state (no resume, no inherited log config), deletes the state file.
- **Defer `StepperData` injection** in `New-Step.ps1` to the Resume branches only — a fresh run never loads prior-run data.
- **Gate log-config restore on an actual resume** via a `StartFresh` flag, so Start Over re-resolves logging from scratch.
- **All 8 fresh-start branches** (both menus, their More-details sub-menus, invalid-input defaults, and the all-steps-complete auto-fresh) route through `Clear-StepperSession`; menu loops get an idempotency guard so a re-looped menu breaks instead of re-prompting.

## Behavior change

Start Over now discards the previous run's logging choices and re-prompts where the script asks. Documented in `Docs/how-it-works.md`.

## Tests

New regression canary `Start Over does not reuse data from previous runs` covers stale `$Stepper` removal, log-config reset, restart at step 1, and clean re-persisted state. Suite: 90 passed, 5 failed — the 5 are pre-existing `Assert-MockCalled`/Pester v6 harness noise tracked separately in #74, unrelated to this change.

## Notes

One spec deviation (recorded on #72): the design said to clear the `__StepperInitialized` sentinel at fresh start, but the first step sets it *after* the menu runs — clearing it caused a re-prompt loop that hung non-interactive runs. Freshness is achieved via the `StartFresh` flag + state-file delete + log-config reset instead.

Also includes `6225c1d` (docs): removes an aspirational `CHANGELOG.MD` requirement from `copilot-instructions.md` — the repo has no changelog.

Closes the investigation started in #69.
