### PR TITLE
fix(validation): initialize $Stepper for converted scripts + harden module-frame detection

### DIFF
--- a/Private/Get-StepIdentifier.ps1
+++ b/Private/Get-StepIdentifier.ps1
@@ -26,17 +26,25 @@ function Get-StepIdentifier {
             continue
         }
 
-        # Skip frames from the Stepper module directory
+        # Skip frames from the Stepper module, whether loaded from the source repo,
+        # a built artefact, or an installed module copy. The module file is always
+        # named Stepper.psm1 and its functions live under a Stepper/Private or
+        # Stepper/Public directory; matching on the path shape (not the source repo
+        # location) ensures built/installed copies are also recognized as module
+        # frames and never mistaken for the user's script.
         $stepperDir = Split-Path -Path $PSScriptRoot -Parent
         # Normalize paths for cross-platform comparison
         $normalizedScript = $scriptName -replace '[\\/]', [System.IO.Path]::DirectorySeparatorChar
         $normalizedStepperDir = $stepperDir -replace '[\\/]', [System.IO.Path]::DirectorySeparatorChar
+        $sep = [System.IO.Path]::DirectorySeparatorChar
 
-        # Skip if it's from the module's Private/Public folders or the main PSM1
-        if ($normalizedScript -like "$normalizedStepperDir$([System.IO.Path]::DirectorySeparatorChar)Private$([System.IO.Path]::DirectorySeparatorChar)*" -or
-            $normalizedScript -like "$normalizedStepperDir$([System.IO.Path]::DirectorySeparatorChar)Public$([System.IO.Path]::DirectorySeparatorChar)*" -or
-            $normalizedScript -like "$normalizedStepperDir$([System.IO.Path]::DirectorySeparatorChar)Stepper.psm1" -or
-            $normalizedScript -like "*$([System.IO.Path]::DirectorySeparatorChar)Modules$([System.IO.Path]::DirectorySeparatorChar)Stepper$([System.IO.Path]::DirectorySeparatorChar)*") {
+        $isModulePsm1   = $normalizedScript -like "*${sep}Stepper.psm1"
+        $isModuleFolder = $normalizedScript -like "*${sep}Stepper${sep}Private${sep}*" -or
+                          $normalizedScript -like "*${sep}Stepper${sep}Public${sep}*"
+        $isSourceRepo   = $normalizedScript -like "$normalizedStepperDir${sep}Private${sep}*" -or
+                          $normalizedScript -like "$normalizedStepperDir${sep}Public${sep}*"
+
+        if ($isModulePsm1 -or $isModuleFolder -or $isSourceRepo) {
             continue
         }
 

--- a/Private/Get-StepperInitInsertionIndex.ps1
+++ b/Private/Get-StepperInitInsertionIndex.ps1
@@ -1,0 +1,64 @@
+function Get-StepperInitInsertionIndex {
+    <#
+    .SYNOPSIS
+        Finds the line index where the $Stepper initializer should be inserted.
+
+    .DESCRIPTION
+        Returns the 0-based line index (into the array of script lines) at which the
+        idempotent $Stepper initializer should be inserted.
+
+        Preferred placement is inside the first '#region Stepper ignore' block,
+        immediately before its '#endregion' line. The unmanaged-code scanner ignores
+        lines inside these regions, so an initializer placed there is not flagged as
+        a new unmanaged-code block on the next run. When no ignore region exists, the
+        initializer goes immediately after the param() block (or before the first
+        statement when there is no param block).
+
+        Shared by ConvertTo-StepperScript and Repair-StepperScript so both insert the
+        initializer in the same place.
+
+    .PARAMETER ScriptPath
+        Path to the script file to analyze.
+
+    .OUTPUTS
+        System.Int32 - 0-based insertion line index.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ScriptPath
+    )
+
+    $scriptLines = Get-Content -Path $ScriptPath -ErrorAction Stop
+
+    # Prefer inside the first '#region Stepper ignore' block, before its '#endregion'.
+    # The scanner only ignores lines within a region/endregion pair.
+    for ($i = 0; $i -lt $scriptLines.Count; $i++) {
+        if ($scriptLines[$i] -match '^\s*#region\s+Stepper\s+ignore') {
+            # Find the matching #endregion and insert just before it
+            for ($j = $i + 1; $j -lt $scriptLines.Count; $j++) {
+                if ($scriptLines[$j] -match '^\s*#endregion\s+Stepper\s+ignore') {
+                    return $j
+                }
+            }
+            # Region opened but never closed; fall through to param-based placement
+            break
+        }
+    }
+
+    $parsedAst = Get-ScriptAst -ScriptPath $ScriptPath
+
+    if ($parsedAst.Ast.ParamBlock) {
+        # Insert on the line immediately after the param() block's closing line
+        return $parsedAst.Ast.ParamBlock.Extent.EndLineNumber
+    }
+
+    # No param block: insert before the first top-level statement
+    $firstStatement = @($parsedAst.Ast.EndBlock.Statements) | Select-Object -First 1
+    if ($firstStatement) {
+        return $firstStatement.Extent.StartLineNumber - 1
+    }
+
+    return 0
+}

--- a/Public/ConvertTo-StepperScript.ps1
+++ b/Public/ConvertTo-StepperScript.ps1
@@ -236,8 +236,45 @@ function ConvertTo-StepperScript {
         $content = $prefix + $replacement + $suffix
     }
 
-    # Inject $StepperConversionComplete sentinel inside the #region Stepper ignore block
+    # Ensure $Stepper is initialized before the first converted assignment runs.
+    # Only needed when a converted cross-step variable is first assigned in
+    # unmanaged code (before the first New-Step call) — inside a New-Step body the
+    # step's own init creates $Stepper first. Insert an idempotent initializer via
+    # the shared placement helper so the converted script is runnable.
     $nl = [System.Environment]::NewLine
+    $initializer = "if (`$null -eq `$Stepper) { `$Stepper = @{} }"
+    if ($content -notmatch 'if \(\$null -eq \$Stepper\)') {
+        $blocks = Find-NewStepBlocks -ScriptPath $resolvedPath
+        # Find-NewStepBlocks.Start is 0-based; AST StartLineNumber is 1-based.
+        $firstStepLine = if ($blocks.NewStepBlocks.Count -gt 0) {
+            (($blocks.NewStepBlocks | ForEach-Object { $_.Start } | Measure-Object -Minimum).Minimum) + 1
+        } else {
+            [int]::MaxValue
+        }
+        $initAst = [System.Management.Automation.Language.Parser]::ParseInput(
+            $content, [ref]$null, [ref]$null
+        )
+        $hasPreStepAssignment = @($initAst.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+            $node.Left -is [System.Management.Automation.Language.MemberExpressionAst] -and
+            $node.Left.Expression -is [System.Management.Automation.Language.VariableExpressionAst] -and
+            $node.Left.Expression.VariablePath.UserPath -eq 'Stepper' -and
+            $node.Extent.StartLineNumber -lt $firstStepLine
+        }, $true)).Count -gt 0
+
+        if ($hasPreStepAssignment) {
+            $scriptLines = $content -split '\r?\n'
+            $insertIndex = Get-StepperInitInsertionIndex -ScriptPath $resolvedPath
+            $newLines = @()
+            for ($i = 0; $i -lt $insertIndex; $i++) { $newLines += $scriptLines[$i] }
+            $newLines += $initializer
+            for ($i = $insertIndex; $i -lt $scriptLines.Count; $i++) { $newLines += $scriptLines[$i] }
+            $content = $newLines -join $nl
+        }
+    }
+
+    # Inject $StepperConversionComplete sentinel inside the #region Stepper ignore block
     $endRegionPattern = '#endregion Stepper ignore'
     $endRegionIndex = $content.IndexOf($endRegionPattern)
 

--- a/Public/ConvertTo-StepperScript.ps1
+++ b/Public/ConvertTo-StepperScript.ps1
@@ -238,30 +238,45 @@ function ConvertTo-StepperScript {
 
     # Ensure $Stepper is initialized before the first converted assignment runs.
     # Only needed when a converted cross-step variable is first assigned in
-    # unmanaged code (before the first New-Step call) — inside a New-Step body the
-    # step's own init creates $Stepper first. Insert an idempotent initializer via
-    # the shared placement helper so the converted script is runnable.
+    # unmanaged code (outside any New-Step body) — inside a New-Step body the
+    # step's own init creates $Stepper first. Detection keys off containment within
+    # a New-Step scriptblock, not line order, so a blank bootstrap New-Step does not
+    # suppress the initializer. Insert via the shared placement helper.
     $nl = [System.Environment]::NewLine
     $initializer = "if (`$null -eq `$Stepper) { `$Stepper = @{} }"
     if ($content -notmatch 'if \(\$null -eq \$Stepper\)') {
-        $blocks = Find-NewStepBlocks -ScriptPath $resolvedPath
-        # Find-NewStepBlocks.Start is 0-based; AST StartLineNumber is 1-based.
-        $firstStepLine = if ($blocks.NewStepBlocks.Count -gt 0) {
-            (($blocks.NewStepBlocks | ForEach-Object { $_.Start } | Measure-Object -Minimum).Minimum) + 1
-        } else {
-            [int]::MaxValue
-        }
         $initAst = [System.Management.Automation.Language.Parser]::ParseInput(
             $content, [ref]$null, [ref]$null
         )
-        $hasPreStepAssignment = @($initAst.FindAll({
+        $newStepCalls = @($initAst.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.CommandAst] -and
+            $node.GetCommandName() -eq 'New-Step'
+        }, $true))
+        $stepBodyExtents = @()
+        foreach ($call in $newStepCalls) {
+            $sb = $call.CommandElements | Where-Object { $_ -is [System.Management.Automation.Language.ScriptBlockExpressionAst] } | Select-Object -First 1
+            if ($sb) { $stepBodyExtents += $sb.Extent }
+        }
+        $stepperAssignments = @($initAst.FindAll({
             param($node)
             $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
             $node.Left -is [System.Management.Automation.Language.MemberExpressionAst] -and
             $node.Left.Expression -is [System.Management.Automation.Language.VariableExpressionAst] -and
-            $node.Left.Expression.VariablePath.UserPath -eq 'Stepper' -and
-            $node.Extent.StartLineNumber -lt $firstStepLine
-        }, $true)).Count -gt 0
+            $node.Left.Expression.VariablePath.UserPath -eq 'Stepper'
+        }, $true))
+        $hasPreStepAssignment = @($stepperAssignments | Where-Object {
+            $assign = $_
+            $insideStep = $false
+            foreach ($extent in $stepBodyExtents) {
+                if ($assign.Extent.StartOffset -ge $extent.StartOffset -and
+                    $assign.Extent.EndOffset -le $extent.EndOffset) {
+                    $insideStep = $true
+                    break
+                }
+            }
+            -not $insideStep
+        }).Count -gt 0
 
         if ($hasPreStepAssignment) {
             $scriptLines = $content -split '\r?\n'

--- a/Public/New-Step.ps1
+++ b/Public/New-Step.ps1
@@ -209,7 +209,15 @@ function New-Step {
             $preRepairResult = Test-StepperScript -ScriptPath $scriptPath
             $needsRestart    = $preRepairResult.Issues |
                 Where-Object { $_.Code -in 'MissingCmdletBinding', 'MissingInstallGuard' }
-            Repair-StepperScript -ScriptPath $scriptPath -WarningAction SilentlyContinue | Out-Null
+
+            # Auto-repair only the structural/declarative issues. UninitializedStepper
+            # is a semantic change to the user's script and is handled via prompt below.
+            $needsAutoRepair = $preRepairResult.Issues |
+                Where-Object { $_.Code -in 'MissingCmdletBinding', 'MissingInstallGuard', 'MissingCbh' }
+            if ($needsAutoRepair) {
+                Repair-StepperScript -ScriptPath $scriptPath -WarningAction SilentlyContinue | Out-Null
+            }
+
             if ($needsRestart) {
                 $scriptName = Split-Path $scriptPath -Leaf
                 $added = ($needsRestart | ForEach-Object {
@@ -222,6 +230,43 @@ function New-Step {
                 Write-Host "$added has been added to $scriptName." -ForegroundColor Green
                 Write-Host "Please re-run $scriptName." -ForegroundColor Green
                 exit
+            }
+
+            # UninitializedStepper is a semantic fix to the user's data initialization,
+            # so ask before repairing. Repair + re-run (the initializer must execute in
+            # a fresh run), ignore-and-continue (script will likely throw), or quit.
+            $uninitStepper = $preRepairResult.Issues | Where-Object { $_.Code -eq 'UninitializedStepper' }
+            if ($uninitStepper) {
+                $scriptName = Split-Path $scriptPath -Leaf
+                Write-Host ""
+                Write-Host "[!] $scriptName assigns `$Stepper.<Var> before Stepper initializes `$Stepper." -ForegroundColor Magenta
+                Write-Host "    This run will fail unless `$Stepper is initialized first."
+                Write-Host ""
+                Write-Host "  [Y] Repair (add initializer) and re-run $scriptName (Default)" -ForegroundColor Cyan
+                Write-Host "  [i] Ignore and continue" -ForegroundColor White
+                Write-Host "  [q] Quit" -ForegroundColor White
+                Write-Host ""
+                Write-Host "Choice? [Y/i/q]: " -NoNewline
+                try {
+                    $uninitChoice = Read-Host
+                } catch {
+                    # Non-interactive context - default to repair (prevents a guaranteed failure)
+                    $uninitChoice = 'y'
+                    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')][Stepper] Non-interactive context detected, defaulting to repair"
+                }
+
+                if ($uninitChoice -eq '' -or $uninitChoice -eq 'Y' -or $uninitChoice -eq 'y') {
+                    Repair-StepperScript -ScriptPath $scriptPath -WarningAction SilentlyContinue -Confirm:$false | Out-Null
+                    Write-Host ""
+                    Write-Host "Initializer added to $scriptName. Please re-run $scriptName." -ForegroundColor Green
+                    exit
+                }
+                elseif ($uninitChoice -eq 'Q' -or $uninitChoice -eq 'q') {
+                    Write-Host ""
+                    Write-Host "Exiting..." -ForegroundColor Yellow
+                    exit
+                }
+                # 'i' or anything else: ignore and continue
             }
         }
 

--- a/Public/Repair-StepperScript.ps1
+++ b/Public/Repair-StepperScript.ps1
@@ -41,13 +41,25 @@ function Repair-StepperScript {
     $initialResult = Test-StepperScript -ScriptPath $ScriptPath
 
     $needsFix = $initialResult.Issues | Where-Object {
-        $_.Code -in 'MissingCmdletBinding', 'MissingInstallGuard', 'MissingCbh'
+        $_.Code -in 'MissingCmdletBinding', 'MissingInstallGuard', 'MissingCbh', 'UninitializedStepper'
     }
 
     if ($needsFix -and $PSCmdlet.ShouldProcess($ScriptPath, 'Repair Stepper script requirements')) {
         $hasMissingCbh        = $needsFix | Where-Object Code -EQ 'MissingCbh'
         $hasMissingCmdlet     = $needsFix | Where-Object Code -EQ 'MissingCmdletBinding'
         $hasMissingGuard      = $needsFix | Where-Object Code -EQ 'MissingInstallGuard'
+        $hasUninitStepper     = $needsFix | Where-Object Code -EQ 'UninitializedStepper'
+
+        if ($hasUninitStepper) {
+            $scriptLines = Get-Content -Path $ScriptPath -ErrorAction Stop
+            $insertIndex = Get-StepperInitInsertionIndex -ScriptPath $ScriptPath
+            $newLines = @()
+            for ($i = 0; $i -lt $insertIndex; $i++) { $newLines += $scriptLines[$i] }
+            $newLines += 'if ($null -eq $Stepper) { $Stepper = @{} }'
+            for ($i = $insertIndex; $i -lt $scriptLines.Count; $i++) { $newLines += $scriptLines[$i] }
+            New-StepperBackup -Path $ScriptPath | Out-Null
+            $newLines | Set-Content -Path $ScriptPath -Force -ErrorAction Stop
+        }
 
         if ($hasMissingCmdlet -or $hasMissingGuard) {
             $scriptLines = Get-Content -Path $ScriptPath -ErrorAction Stop
@@ -135,6 +147,13 @@ function Repair-StepperScript {
 
     foreach ($w in $warnCodes) {
         Write-Warning $w.Message
+    }
+
+    # Surface a repair that was skipped by ShouldProcess (e.g. -WhatIf, or a
+    # high $ConfirmPreference suppressing the Medium-impact change) so it is
+    # not silently a no-op.
+    if ($needsFix -and -not $PSCmdlet.ShouldProcess($ScriptPath, 'Repair Stepper script requirements')) {
+        Write-Verbose "[Stepper] Repair skipped for $ScriptPath (declined, -WhatIf, or ConfirmPreference above Medium). Re-run with -Confirm:`$false to apply."
     }
 
     # Return post-fix result

--- a/Public/Test-StepperScript.ps1
+++ b/Public/Test-StepperScript.ps1
@@ -90,11 +90,21 @@ function Test-StepperScript {
     # (outside any New-Step body) runs before New-Step initializes $Stepper. If no
     # 'if ($null -eq $Stepper)' initializer precedes the first such assignment, the
     # script throws "The property '<Var>' cannot be found on this object."
-    # Find-NewStepBlocks.Start is 0-based; AST StartLineNumber is 1-based.
-    $firstStepLine = if ($blocks.NewStepBlocks.Count -gt 0) {
-        (($blocks.NewStepBlocks | ForEach-Object { $_.Start } | Measure-Object -Minimum).Minimum) + 1
-    } else {
-        [int]::MaxValue
+    #
+    # Detection keys off whether the assignment is contained within a New-Step
+    # scriptblock, NOT line order — a blank bootstrap New-Step placed ahead of the
+    # assignment must not blind the detector.
+    $newStepCalls = @($parsedAst.Ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -eq 'New-Step'
+    }, $true))
+
+    # Collect the scriptblock extents of every New-Step call
+    $stepBodyExtents = @()
+    foreach ($call in $newStepCalls) {
+        $sb = $call.CommandElements | Where-Object { $_ -is [System.Management.Automation.Language.ScriptBlockExpressionAst] } | Select-Object -First 1
+        if ($sb) { $stepBodyExtents += $sb.Extent }
     }
 
     $stepperAssignments = @($parsedAst.Ast.FindAll({
@@ -105,14 +115,24 @@ function Test-StepperScript {
         $node.Left.Expression.VariablePath.UserPath -eq 'Stepper'
     }, $true))
 
+    # Unmanaged = not contained within any New-Step scriptblock extent
     $unmanagedStepperAssign = @($stepperAssignments | Where-Object {
-        $_.Extent.StartLineNumber -lt $firstStepLine
+        $assign = $_
+        $insideStep = $false
+        foreach ($extent in $stepBodyExtents) {
+            if ($assign.Extent.StartOffset -ge $extent.StartOffset -and
+                $assign.Extent.EndOffset -le $extent.EndOffset) {
+                $insideStep = $true
+                break
+            }
+        }
+        -not $insideStep
     })
 
     if ($unmanagedStepperAssign.Count -gt 0 -and $scriptRaw -notmatch 'if\s*\(\s*\$null\s*-eq\s*\$Stepper\s*\)') {
         $firstVar = $unmanagedStepperAssign[0].Left.Member.SafeGetValue()
         $issues.Add((New-StepperIssue -Code 'UninitializedStepper' -Severity 'Error' `
-            -Message "`$Stepper.$firstVar is assigned before New-Step initializes `$Stepper. Add 'if (`$null -eq `$Stepper) { `$Stepper = @{} }' before the first `$Stepper.<Var> assignment, or run Repair-StepperScript."))
+            -Message "`$Stepper.$firstVar is assigned in unmanaged code before New-Step initializes `$Stepper. Add 'if (`$null -eq `$Stepper) { `$Stepper = @{} }' before the first `$Stepper.<Var> assignment, or run Repair-StepperScript."))
     }
 
     # IsValid = no Error-severity issues

--- a/Public/Test-StepperScript.ps1
+++ b/Public/Test-StepperScript.ps1
@@ -85,6 +85,36 @@ function Test-StepperScript {
             -Message "Stop-Stepper is missing. Call Stop-Stepper at the end of the script to mark completion."))
     }
 
+    # --- Error: UninitializedStepper ---
+    # A converted cross-step variable assigned to $Stepper.<Var> in unmanaged code
+    # (outside any New-Step body) runs before New-Step initializes $Stepper. If no
+    # 'if ($null -eq $Stepper)' initializer precedes the first such assignment, the
+    # script throws "The property '<Var>' cannot be found on this object."
+    # Find-NewStepBlocks.Start is 0-based; AST StartLineNumber is 1-based.
+    $firstStepLine = if ($blocks.NewStepBlocks.Count -gt 0) {
+        (($blocks.NewStepBlocks | ForEach-Object { $_.Start } | Measure-Object -Minimum).Minimum) + 1
+    } else {
+        [int]::MaxValue
+    }
+
+    $stepperAssignments = @($parsedAst.Ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $node.Left -is [System.Management.Automation.Language.MemberExpressionAst] -and
+        $node.Left.Expression -is [System.Management.Automation.Language.VariableExpressionAst] -and
+        $node.Left.Expression.VariablePath.UserPath -eq 'Stepper'
+    }, $true))
+
+    $unmanagedStepperAssign = @($stepperAssignments | Where-Object {
+        $_.Extent.StartLineNumber -lt $firstStepLine
+    })
+
+    if ($unmanagedStepperAssign.Count -gt 0 -and $scriptRaw -notmatch 'if\s*\(\s*\$null\s*-eq\s*\$Stepper\s*\)') {
+        $firstVar = $unmanagedStepperAssign[0].Left.Member.SafeGetValue()
+        $issues.Add((New-StepperIssue -Code 'UninitializedStepper' -Severity 'Error' `
+            -Message "`$Stepper.$firstVar is assigned before New-Step initializes `$Stepper. Add 'if (`$null -eq `$Stepper) { `$Stepper = @{} }' before the first `$Stepper.<Var> assignment, or run Repair-StepperScript."))
+    }
+
     # IsValid = no Error-severity issues
     $isValid = -not ($issues | Where-Object Severity -EQ 'Error')
 

--- a/Tests/ConvertTo-StepperScript.Tests.ps1
+++ b/Tests/ConvertTo-StepperScript.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     . "$ModulePath/Private/Get-ScriptAst.ps1"
     . "$ModulePath/Private/Find-NewStepBlocks.ps1"
     . "$ModulePath/Private/Find-CrossStepVariables.ps1"
+    . "$ModulePath/Private/Get-StepperInitInsertionIndex.ps1"
     . "$ModulePath/Private/New-StepperBackup.ps1"
     . "$ModulePath/Private/Test-StepperConversionComplete.ps1"
     . "$ModulePath/Public/ConvertTo-StepperScript.ps1"
@@ -177,6 +178,22 @@ Describe 'ConvertTo-StepperScript' -Tag 'Unit' {
             }
         }
 
+        It 'Should not add the $Stepper initializer when all candidates are assigned inside New-Step blocks' {
+            # CrossStepScript assigns $servers/$count only inside New-Step bodies,
+            # so the initializer is unnecessary and must not be emitted.
+            $path = New-TempScript ($CrossStepScript -split [System.Environment]::NewLine)
+            try {
+                ConvertTo-StepperScript -Path $path -Force
+                $result = Get-Content -Path $path -Raw
+                $result | Should -Match '\$Stepper\.Servers'
+                $result | Should -Not -Match 'if \(\$null -eq \$Stepper\)'
+            }
+            finally {
+                Remove-Item $path -ErrorAction SilentlyContinue
+                Remove-Item "$path.bak" -ErrorAction SilentlyContinue
+            }
+        }
+
         It 'Should create a timestamped .bak backup of the original' {
             $path = New-TempScript ($CrossStepScript -split [System.Environment]::NewLine)
             $originalContent = Get-Content -Path $path -Raw
@@ -201,6 +218,65 @@ Describe 'ConvertTo-StepperScript' -Tag 'Unit' {
                 $errors = $null
                 [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$null, [ref]$errors) | Out-Null
                 $errors | Should -HaveCount 0
+            }
+            finally {
+                Remove-Item $path -ErrorAction SilentlyContinue
+                Remove-Item "$path.bak" -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Should initialize $Stepper before the first converted assignment' {
+            # Cross-step variable first assigned in unmanaged (script-level) code
+            # that runs before any New-Step. Without an initializer the converted
+            # '$Stepper.Name = ...' line fails with "property cannot be found".
+            $scriptWithUnmanagedFirst = @(
+                '[CmdletBinding()]'
+                'param()'
+                '$name = Read-Host "Name?"'
+                'New-Step {'
+                '    Write-Host $name'
+                '}'
+                'Stop-Stepper'
+            ) -join [System.Environment]::NewLine
+            $path = New-TempScript ($scriptWithUnmanagedFirst -split [System.Environment]::NewLine)
+            try {
+                ConvertTo-StepperScript -Path $path -Force
+                $result = Get-Content -Path $path -Raw
+                # An idempotent initializer must appear before the first $Stepper. assignment
+                $result | Should -Match 'if \(\$null -eq \$Stepper\)'
+                $initIndex = $result.IndexOf('if ($null -eq $Stepper)')
+                $assignIndex = $result.IndexOf('$Stepper.Name')
+                $assignIndex | Should -BeGreaterThan -1
+                $initIndex | Should -BeLessThan $assignIndex
+            }
+            finally {
+                Remove-Item $path -ErrorAction SilentlyContinue
+                Remove-Item "$path.bak" -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Should produce a converted script that runs without property errors when a cross-step variable is set in unmanaged code' {
+            # End-to-end: the converted script must be runnable. Dot-source the
+            # converted script body in a child scope with $Stepper undefined and
+            # confirm the unmanaged assignment no longer throws.
+            $scriptWithUnmanagedFirst = @(
+                '[CmdletBinding()]'
+                'param()'
+                '$name = "seed"'
+                'New-Step {'
+                '    Write-Host $name'
+                '}'
+                'Stop-Stepper'
+            ) -join [System.Environment]::NewLine
+            $path = New-TempScript ($scriptWithUnmanagedFirst -split [System.Environment]::NewLine)
+            try {
+                ConvertTo-StepperScript -Path $path -Force
+                $result = Get-Content -Path $path -Raw
+                # Execute only up to (but excluding) the first New-Step call,
+                # simulating the unmanaged prefix that runs before step init.
+                $prefix = $result.Substring(0, $result.IndexOf('New-Step'))
+                $prefix = $prefix -replace '\[CmdletBinding\(\)\]', '' -replace 'param\(\)', ''
+                { Invoke-Expression $prefix } | Should -Not -Throw
             }
             finally {
                 Remove-Item $path -ErrorAction SilentlyContinue

--- a/Tests/ConvertTo-StepperScript.Tests.ps1
+++ b/Tests/ConvertTo-StepperScript.Tests.ps1
@@ -194,6 +194,28 @@ Describe 'ConvertTo-StepperScript' -Tag 'Unit' {
             }
         }
 
+        It 'Should add the $Stepper initializer even when a blank New-Step bootstrap precedes the unmanaged assignment' {
+            # Regression: a blank bootstrap New-Step must not suppress the initializer.
+            $scriptWithBootstrap = @(
+                '[CmdletBinding()]'
+                'param()'
+                'New-Step { }'
+                '$name = "Jake"'
+                'New-Step { Write-Host $name }'
+                'Stop-Stepper'
+            ) -join [System.Environment]::NewLine
+            $path = New-TempScript ($scriptWithBootstrap -split [System.Environment]::NewLine)
+            try {
+                ConvertTo-StepperScript -Path $path -Force
+                $result = Get-Content -Path $path -Raw
+                $result | Should -Match 'if \(\$null -eq \$Stepper\)'
+            }
+            finally {
+                Remove-Item $path -ErrorAction SilentlyContinue
+                Remove-Item "$path.bak" -ErrorAction SilentlyContinue
+            }
+        }
+
         It 'Should create a timestamped .bak backup of the original' {
             $path = New-TempScript ($CrossStepScript -split [System.Environment]::NewLine)
             $originalContent = Get-Content -Path $path -Raw

--- a/Tests/Get-StepIdentifier.Tests.ps1
+++ b/Tests/Get-StepIdentifier.Tests.ps1
@@ -182,4 +182,59 @@ Describe 'Get-StepIdentifier' -Tag 'Unit' {
             $result | Should -Be "${script:UserScript4}:12"
         }
     }
+
+    Context 'When Stepper.psm1 frame comes from a built artefact (not the source repo)' {
+        # Regression: Get-StepIdentifier used to skip module frames only by comparing
+        # against the source repo path, so a built artefact's Stepper.psm1 frame was
+        # mistaken for the user's script and New-Step validated/repaired the module.
+        BeforeAll {
+            $script:UserScript5 = Join-Path $TestDrive 'user-script5.ps1'
+            Set-Content -Path $script:UserScript5 -Value 'New-Step { }'
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $script:ArtefactFrames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${TestDrive}${sep}Artefacts${sep}Unpacked${sep}Stepper${sep}Stepper.psm1"
+                    ScriptLineNumber = 8
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $script:UserScript5
+                    ScriptLineNumber = 5
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack { $script:ArtefactFrames }
+        }
+
+        It 'Skips the built artefact Stepper.psm1 frame and returns the user script' {
+            $result = Get-StepIdentifier
+            $result | Should -Be "${script:UserScript5}:5"
+        }
+    }
+
+    Context 'When module frames come from an installed module path' {
+        BeforeAll {
+            $script:UserScript6 = Join-Path $TestDrive 'user-script6.ps1'
+            Set-Content -Path $script:UserScript6 -Value 'New-Step { }'
+            $sep = [System.IO.Path]::DirectorySeparatorChar
+            $script:InstalledFrames = @(
+                [PSCustomObject]@{
+                    ScriptName       = "${TestDrive}${sep}Modules${sep}Stepper${sep}Stepper.psm1"
+                    ScriptLineNumber = 700
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                },
+                [PSCustomObject]@{
+                    ScriptName       = $script:UserScript6
+                    ScriptLineNumber = 2
+                    InvocationInfo   = [PSCustomObject]@{ BoundParameters = @{} }
+                }
+            )
+            Mock Get-PSCallStack { $script:InstalledFrames }
+        }
+
+        It 'Skips the installed Stepper.psm1 frame and returns the user script' {
+            $result = Get-StepIdentifier
+            $result | Should -Be "${script:UserScript6}:2"
+        }
+    }
 }

--- a/Tests/New-Step.Tests.ps1
+++ b/Tests/New-Step.Tests.ps1
@@ -1278,12 +1278,54 @@ Describe 'New-Step' -Tag 'Integration' {
             Should -Invoke Repair-StepperScript -Exactly 0 -Scope It
         }
 
-        It 'Should call Repair-StepperScript when not specified' {
+        It 'Should call Repair-StepperScript when an auto-repairable issue is present' {
             $info = New-TestStepperScript
             Mock Get-StepIdentifier { "$($info.Path):$($info.FirstStepLine)" }
+            Mock Test-StepperScript {
+                [PSCustomObject]@{
+                    IsValid = $false
+                    Issues  = @([PSCustomObject]@{ Code = 'MissingCbh'; Severity = 'Warning'; Message = 'x' })
+                }
+            }
 
             New-Step { }
             Should -Invoke Repair-StepperScript -Exactly 1 -Scope It
+        }
+
+        It 'Should prompt before repairing when Test-StepperScript reports UninitializedStepper' {
+            $info = New-TestStepperScript
+            Mock Get-StepIdentifier { "$($info.Path):$($info.FirstStepLine)" }
+            Mock Test-StepperScript {
+                [PSCustomObject]@{
+                    IsValid = $false
+                    Issues  = @([PSCustomObject]@{ Code = 'UninitializedStepper'; Severity = 'Error'; Message = 'x' })
+                }
+            }
+            # Answering 'Y' triggers repair + exit; the throw intercepts the exit.
+            Mock Read-Host { 'Y' }
+            Mock Repair-StepperScript { throw 'repair-intercept' }
+            Mock Write-Host {}
+
+            { New-Step { } } | Should -Throw 'repair-intercept'
+            Should -Invoke Read-Host -Exactly 1 -Scope It
+            Should -Invoke Repair-StepperScript -Exactly 1 -Scope It
+        }
+
+        It 'Should not repair when the user answers Ignore to the UninitializedStepper prompt' {
+            $info = New-TestStepperScript
+            Mock Get-StepIdentifier { "$($info.Path):$($info.FirstStepLine)" }
+            Mock Test-StepperScript {
+                [PSCustomObject]@{
+                    IsValid = $false
+                    Issues  = @([PSCustomObject]@{ Code = 'UninitializedStepper'; Severity = 'Error'; Message = 'x' })
+                }
+            }
+            Mock Read-Host { 'i' }
+            Mock Repair-StepperScript { throw 'repair-should-not-run' }
+            Mock Write-Host {}
+
+            { New-Step { } } | Should -Not -Throw 'repair-should-not-run'
+            Should -Invoke Repair-StepperScript -Exactly 0 -Scope It
         }
     }
 

--- a/Tests/Repair-StepperScript.Tests.ps1
+++ b/Tests/Repair-StepperScript.Tests.ps1
@@ -3,9 +3,11 @@ BeforeAll {
     . "$ModulePath/Private/Get-ScriptHash.ps1"
     . "$ModulePath/Private/Get-ScriptAst.ps1"
     . "$ModulePath/Private/Find-NewStepBlocks.ps1"
+    . "$ModulePath/Private/Find-UnmanagedCodeBlocks.ps1"
     . "$ModulePath/Private/Add-StepperCbh.ps1"
     . "$ModulePath/Private/New-StepperIssue.ps1"
     . "$ModulePath/Private/New-StepperBackup.ps1"
+    . "$ModulePath/Private/Get-StepperInitInsertionIndex.ps1"
     . "$ModulePath/Public/Test-StepperScript.ps1"
     . "$ModulePath/Public/Repair-StepperScript.ps1"
 
@@ -18,6 +20,102 @@ BeforeAll {
 }
 
 Describe 'Repair-StepperScript' -Tag 'Unit' {
+
+    Context 'UninitializedStepper repair' {
+        It 'Inserts the $Stepper initializer after param() when an unmanaged $Stepper assignment is uninitialised' {
+            $path = New-TempScript @(
+                '<#'
+                '.SYNOPSIS'
+                '    s.'
+                '#>'
+                '[CmdletBinding()]'
+                'param()'
+                'if (-not (Get-Module Stepper)) { Install-Module Stepper -Force }'
+                '$Stepper.Name = Read-Host "Name?"'
+                'New-Step { Write-Host $Stepper.Name }'
+                'Stop-Stepper'
+            )
+            try {
+                Repair-StepperScript -ScriptPath $path | Out-Null
+                $result = Get-Content -Path $path -Raw
+                $result | Should -Match 'if \(\$null -eq \$Stepper\)'
+                # Initializer must come after param() and before the assignment
+                $initIndex   = $result.IndexOf('if ($null -eq $Stepper)')
+                $paramIndex  = $result.IndexOf('param()')
+                $assignIndex = $result.IndexOf('$Stepper.Name')
+                $initIndex | Should -BeGreaterThan $paramIndex
+                $initIndex | Should -BeLessThan $assignIndex
+                # Script must still parse
+                $errors = $null
+                [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$null, [ref]$errors) | Out-Null
+                $errors | Should -HaveCount 0
+            }
+            finally {
+                Remove-Item $path -ErrorAction SilentlyContinue
+                Get-ChildItem (Split-Path $path) -Filter "$( [System.IO.Path]::GetFileNameWithoutExtension($path) ).*.ps1.bak" | Remove-Item -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Clears the UninitializedStepper issue after repair' {
+            $path = New-TempScript @(
+                '<#'
+                '.SYNOPSIS'
+                '    s.'
+                '#>'
+                '[CmdletBinding()]'
+                'param()'
+                'if (-not (Get-Module Stepper)) { Install-Module Stepper -Force }'
+                '$Stepper.Name = Read-Host "Name?"'
+                'New-Step { Write-Host $Stepper.Name }'
+                'Stop-Stepper'
+            )
+            try {
+                $after = Repair-StepperScript -ScriptPath $path
+                $after.Issues | Where-Object Code -EQ 'UninitializedStepper' | Should -BeNullOrEmpty
+            }
+            finally {
+                Remove-Item $path -ErrorAction SilentlyContinue
+                Get-ChildItem (Split-Path $path) -Filter "$( [System.IO.Path]::GetFileNameWithoutExtension($path) ).*.ps1.bak" | Remove-Item -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Places the initializer inside a Stepper ignore region so the scanner does not flag it' {
+            # Regression: an initializer left in unmanaged code is detected as a new
+            # unmanaged-code block on the next run, prompting wrap/delete/ignore.
+            # Fixture mirrors a real converted script: the unmanaged $Stepper.Name
+            # assignment lives inside its own ignore region, so after repair the only
+            # ignored pre-step lines are the regions themselves.
+            $path = New-TempScript @(
+                '<#'
+                '.SYNOPSIS'
+                '    s.'
+                '#>'
+                '[CmdletBinding()]'
+                'param()'
+                '#region Stepper ignore'
+                'if (-not (Get-Module Stepper)) { Install-Module Stepper -Force }'
+                '#endregion Stepper ignore'
+                '#region Stepper ignore'
+                '$Stepper.Name = Read-Host "Name?"'
+                '#endregion Stepper ignore'
+                'New-Step { Write-Host $Stepper.Name }'
+                'Stop-Stepper'
+            )
+            try {
+                Repair-StepperScript -ScriptPath $path | Out-Null
+                $lines = Get-Content -Path $path
+                $blocks = Find-NewStepBlocks -ScriptPath $path
+                $unmanaged = Find-UnmanagedCodeBlocks -ScriptLines $lines -NewStepBlocks $blocks.NewStepBlocks -StopStepperLine $blocks.StopStepperLine
+                $flaggedLines = @($unmanaged | ForEach-Object { $_.Lines })
+                $initLineIndex = ($lines | Select-String 'if \(\$null -eq \$Stepper\)').LineNumber - 1
+                $flaggedLines | Should -Not -Contain $initLineIndex
+            }
+            finally {
+                Remove-Item $path -ErrorAction SilentlyContinue
+                Get-ChildItem (Split-Path $path) -Filter "$( [System.IO.Path]::GetFileNameWithoutExtension($path) ).*.ps1.bak" | Remove-Item -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
 
     Context 'Return value' {
         It 'Should accept -Path as an alias for -ScriptPath' {

--- a/Tests/Test-StepperScript.Tests.ps1
+++ b/Tests/Test-StepperScript.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     . "$ModulePath/Private/Get-ScriptAst.ps1"
     . "$ModulePath/Private/Find-NewStepBlocks.ps1"
     . "$ModulePath/Private/New-StepperIssue.ps1"
+    . "$ModulePath/Private/Get-StepperInitInsertionIndex.ps1"
     . "$ModulePath/Public/Test-StepperScript.ps1"
 
     function New-TempScript {
@@ -32,6 +33,81 @@ BeforeAll {
 }
 
 Describe 'Test-StepperScript' -Tag 'Unit' {
+
+    Context 'UninitializedStepper detection' {
+        It 'Flags a converted $Stepper.<Var> assignment before the first New-Step with no initializer' {
+            $path = New-TempScript @(
+                '<#'
+                '.SYNOPSIS'
+                '    s.'
+                '#>'
+                '[CmdletBinding()]'
+                'param()'
+                'if (-not (Get-Module Stepper)) { Install-Module Stepper -Force }'
+                '$Stepper.Name = Read-Host "Name?"'
+                'New-Step { Write-Host $Stepper.Name }'
+                'Stop-Stepper'
+            )
+            try {
+                $r = Test-StepperScript -ScriptPath $path
+                $issue = $r.Issues | Where-Object Code -EQ 'UninitializedStepper'
+                $issue | Should -Not -BeNullOrEmpty
+                $issue.Severity | Should -Be 'Error'
+                $r.IsValid | Should -BeFalse
+            }
+            finally { Remove-Item $path -ErrorAction SilentlyContinue }
+        }
+
+        It 'Does not flag when the initializer precedes the first unmanaged $Stepper assignment' {
+            $path = New-TempScript @(
+                '<#'
+                '.SYNOPSIS'
+                '    s.'
+                '#>'
+                '[CmdletBinding()]'
+                'param()'
+                'if (-not (Get-Module Stepper)) { Install-Module Stepper -Force }'
+                'if ($null -eq $Stepper) { $Stepper = @{} }'
+                '$Stepper.Name = Read-Host "Name?"'
+                'New-Step { Write-Host $Stepper.Name }'
+                'Stop-Stepper'
+            )
+            try {
+                $r = Test-StepperScript -ScriptPath $path
+                $r.Issues | Where-Object Code -EQ 'UninitializedStepper' | Should -BeNullOrEmpty
+            }
+            finally { Remove-Item $path -ErrorAction SilentlyContinue }
+        }
+
+        It 'Does not flag when $Stepper is only assigned inside New-Step blocks' {
+            $path = New-TempScript @(
+                '<#'
+                '.SYNOPSIS'
+                '    s.'
+                '#>'
+                '[CmdletBinding()]'
+                'param()'
+                'if (-not (Get-Module Stepper)) { Install-Module Stepper -Force }'
+                'New-Step { $Stepper.Name = "x" }'
+                'New-Step { Write-Host $Stepper.Name }'
+                'Stop-Stepper'
+            )
+            try {
+                $r = Test-StepperScript -ScriptPath $path
+                $r.Issues | Where-Object Code -EQ 'UninitializedStepper' | Should -BeNullOrEmpty
+            }
+            finally { Remove-Item $path -ErrorAction SilentlyContinue }
+        }
+
+        It 'Does not flag a script with no $Stepper member assignments' {
+            $path = New-TempScript ($ValidScript -split [System.Environment]::NewLine)
+            try {
+                $r = Test-StepperScript -ScriptPath $path
+                $r.Issues | Where-Object Code -EQ 'UninitializedStepper' | Should -BeNullOrEmpty
+            }
+            finally { Remove-Item $path -ErrorAction SilentlyContinue }
+        }
+    }
 
     Context 'Return type' {
         It 'Should return a PSCustomObject' {

--- a/Tests/Test-StepperScript.Tests.ps1
+++ b/Tests/Test-StepperScript.Tests.ps1
@@ -107,6 +107,52 @@ Describe 'Test-StepperScript' -Tag 'Unit' {
             }
             finally { Remove-Item $path -ErrorAction SilentlyContinue }
         }
+
+        It 'Flags an unmanaged $Stepper assignment even when a blank New-Step bootstrap precedes it' {
+            # Regression: a blank New-Step added as a bootstrap becomes the "first"
+            # step, so a line-order predicate goes blind to the real assignment that
+            # follows it. Detection must key off unmanaged code, not line order.
+            $path = New-TempScript @(
+                '<#'
+                '.SYNOPSIS'
+                '    s.'
+                '#>'
+                '[CmdletBinding()]'
+                'param()'
+                'if (-not (Get-Module Stepper)) { Install-Module Stepper -Force }'
+                'New-Step { }'
+                '$Stepper.Name = Read-Host "Name?"'
+                'New-Step { Write-Host $Stepper.Name }'
+                'Stop-Stepper'
+            )
+            try {
+                $r = Test-StepperScript -ScriptPath $path
+                $r.Issues | Where-Object Code -EQ 'UninitializedStepper' | Should -Not -BeNullOrEmpty
+            }
+            finally { Remove-Item $path -ErrorAction SilentlyContinue }
+        }
+
+        It 'Flags a $Stepper assignment inside a Stepper ignore region (unmanaged by definition)' {
+            $path = New-TempScript @(
+                '<#'
+                '.SYNOPSIS'
+                '    s.'
+                '#>'
+                '[CmdletBinding()]'
+                'param()'
+                'if (-not (Get-Module Stepper)) { Install-Module Stepper -Force }'
+                '#region Stepper ignore'
+                '$Stepper.Name = Read-Host "Name?"'
+                '#endregion Stepper ignore'
+                'New-Step { Write-Host $Stepper.Name }'
+                'Stop-Stepper'
+            )
+            try {
+                $r = Test-StepperScript -ScriptPath $path
+                $r.Issues | Where-Object Code -EQ 'UninitializedStepper' | Should -Not -BeNullOrEmpty
+            }
+            finally { Remove-Item $path -ErrorAction SilentlyContinue }
+        }
     }
 
     Context 'Return type' {


### PR DESCRIPTION
## What

Fixes a family of bugs around `$Stepper` initialization for converted scripts, surfaced while validating the Start Over fix (#75).

## The bugs

1. **Crash on converted scripts (#76).** `ConvertTo-StepperScript` rewrites cross-step variables to `$Stepper.<Var>` but never initializes `$Stepper`. A converted variable first assigned in unmanaged code (a `#region Stepper ignore` block) runs before any `New-Step`, where `$Stepper` is still `$null` → "The property '<Var>' cannot be found on this object."
2. **Module self-corruption.** `Get-StepIdentifier` recognized module frames only by source-repo path, so a built/installed `Stepper.psm1` was mistaken for the user's script; `New-Step` then validated and "repaired" the module file, injecting a top-level `[CmdletBinding()] param()`.
3. **Detection blind spot.** The initial `UninitializedStepper` detector keyed off line order, so a blank bootstrap `New-Step { }` ahead of the assignment suppressed detection.

## The fix

- **`Get-StepIdentifier`** recognizes module frames by path shape (`Stepper.psm1`, `Stepper/Private/*`, `Stepper/Public/*`), regardless of where the module loads from. (commit `94994ff`)
- **`UninitializedStepper` detection + repair** (`f74cffe`): `Test-StepperScript` flags a `$Stepper.<Var>` assignment in unmanaged code as an Error; `Repair-StepperScript` inserts `if ($null -eq $Stepper) { $Stepper = @{} }` inside the first ignore region; `New-Step` prompts `[Y] Repair + re-run / [i] Ignore / [q] Quit` rather than auto-repairing (the fix is semantic).
- **Containment-based detection** (`2f84256`): detection keys off whether the assignment is inside a `New-Step` scriptblock, not line order — a blank bootstrap step no longer blinds it.

## Tests

Full suite green (385 passed; the 5 failures are the pre-existing `Assert-MockCalled`/Pester v6 harness noise in #74, unrelated). New coverage across `Test-StepperScript`, `Repair-StepperScript`, `ConvertTo-StepperScript`, `Get-StepIdentifier`, and `New-Step`, including regression tests for the module-corruption path and the bootstrap blind spot. Verified end-to-end against a live converted script.

## Notes

- Behaviour change: `New-Step` auto-repair is now scoped to structural issues (`MissingCmdletBinding`, `MissingInstallGuard`, `MissingCbh`); `UninitializedStepper` prompts instead.
- A follow-up enhancement (a dedicated `Import-Stepper` cmdlet that owns init/state-restore/resume before unmanaged code runs) is being scoped separately — it makes resume-aware unmanaged reads work without the bootstrap hack.

Fixes #76
