### PR TITLE
test(retry): replace Assert-MockCalled with Should -Invoke for Pester v6

### DIFF
--- a/Tests/New-Step.Tests.ps1
+++ b/Tests/New-Step.Tests.ps1
@@ -1233,7 +1233,7 @@ Describe 'New-Step' -Tag 'Integration' {
                 $counter.Calls++
                 if ($counter.Calls -lt 2) { throw 'transient' }
             }
-            Assert-MockCalled Write-Host -ParameterFilter { $Object -match '\[>\]' } -Exactly 1 -Scope It
+            Should -Invoke Write-Host -ParameterFilter { $Object -match '\[>\]' } -Exactly 1 -Scope It
         }
 
         It 'Includes wait time in retry indicator message' {
@@ -1242,7 +1242,7 @@ Describe 'New-Step' -Tag 'Integration' {
                 $counter.Calls++
                 if ($counter.Calls -lt 2) { throw 'transient' }
             }
-            Assert-MockCalled Write-Host -ParameterFilter { $Object -match 'Retrying in \d+s' } -Exactly 1 -Scope It
+            Should -Invoke Write-Host -ParameterFilter { $Object -match 'Retrying in \d+s' } -Exactly 1 -Scope It
         }
 
         It 'Includes attempt number in retry indicator message' {
@@ -1251,12 +1251,12 @@ Describe 'New-Step' -Tag 'Integration' {
                 $counter.Calls++
                 if ($counter.Calls -lt 2) { throw 'transient' }
             }
-            Assert-MockCalled Write-Host -ParameterFilter { $Object -match 'attempt 2 of' } -Exactly 1 -Scope It
+            Should -Invoke Write-Host -ParameterFilter { $Object -match 'attempt 2 of' } -Exactly 1 -Scope It
         }
 
         It 'Does not display retry indicator when retry is not enabled' {
             New-Step { }
-            Assert-MockCalled Write-Host -ParameterFilter { $Object -match '\[>\]' } -Exactly 0 -Scope It
+            Should -Invoke Write-Host -ParameterFilter { $Object -match '\[>\]' } -Exactly 0 -Scope It
         }
 
         It 'Displays retry indicator with Yellow foreground color' {
@@ -1265,7 +1265,7 @@ Describe 'New-Step' -Tag 'Integration' {
                 $counter.Calls++
                 if ($counter.Calls -lt 2) { throw 'transient' }
             }
-            Assert-MockCalled Write-Host -ParameterFilter { $ForegroundColor -eq 'Yellow' } -Exactly 1 -Scope It
+            Should -Invoke Write-Host -ParameterFilter { $ForegroundColor -eq 'Yellow' } -Exactly 1 -Scope It
         }
     }
 


### PR DESCRIPTION
## What

Fixes the 5 failing `Retry: visual indicator` tests so the PSGallery publish workflow's Pester gate passes.

## Root cause

Pester v6 removed `Assert-MockCalled`. The 5 tests in `Tests/New-Step.Tests.ps1` that used it failed with "Should operator 'Be' is not registered" (the command fails to load under v6), and the publish workflow runs `Invoke-Pester -CI` and aborts on any failure — so no release could ship.

## The fix

Replace the 5 `Assert-MockCalled` calls with the equivalent `Should -Invoke <cmd> -ParameterFilter { ... } -Exactly N -Scope It` form already used throughout the suite. Test-only change; no product code touched.

## Verification

Full suite under Pester 6.1.0: 373 passed, 0 failed, 2 skipped.

Fixes #74
