### PR TITLE
test(resume): make pristine Start Over canary host-independent

### DIFF
--- a/Tests/New-Step.Tests.ps1
+++ b/Tests/New-Step.Tests.ps1
@@ -400,7 +400,8 @@ Describe 'New-Step' -Tag 'Integration' {
             }
             Mock Read-Host { 'S' }
 
-            New-Step { }
+            $step1Ran = Join-Path $TestDrive "pristine-step1-$(New-Guid).txt"
+            New-Step { Set-Content -Path $step1Ran -Value 'ran' }
 
             # The stale $Stepper was removed from the caller's scope: it is no
             # longer visible here (the leak path is closed). New-Step recreates
@@ -408,12 +409,14 @@ Describe 'New-Step' -Tag 'Integration' {
             $stepperVar = Get-Variable -Name 'Stepper' -ValueOnly -ErrorAction SilentlyContinue
             $stepperVar | Should -BeNullOrEmpty
 
-            # Execution state is fresh, not resumed from the prior run
-            $execState = Get-Variable -Name '__StepperExecutionState' -ValueOnly
-            $execState.RestoreMode | Should -BeFalse
-            $execState.TargetStep | Should -BeNullOrEmpty
-            $execState.LogPath | Should -Not -Be (Join-Path $TestDrive 'old.log')
-            $execState.NoLogStepIds | Should -Not -Contain $step2Id
+            # Fresh, not resumed: step 1 executed again despite the pre-state
+            # recording it as already completed.
+            $step1Ran | Should -Exist
+
+            # Log config from the old run is discarded, not carried into the new state
+            $state = Import-Clixml -Path $info.StatePath
+            $state.LogPath | Should -Not -Be (Join-Path $TestDrive 'old.log')
+            if ($state.NoLogStepIds) { $state.NoLogStepIds | Should -Not -Contain $step2Id }
 
             New-Step { }
 


### PR DESCRIPTION
## What

Fixes the pristine Start Over canary failing in CI, which blocked the publish gate.

## Root cause

The canary `Start Over does not reuse data from previous runs` read the in-memory `__StepperExecutionState` sentinel from the test's scope via `Get-Variable`. That works in an interactive host but throws `ItemNotFoundException` in headless CI (ubuntu), where the variable is set in a different session-state scope. The publish workflow's `Invoke-Pester -CI` aborts on any failure, so this blocked release.

## The fix

Assert the fresh-run guarantees through host-independent seams instead of the in-memory sentinel:

- step 1 re-executes (side-effect file exists) despite the pre-state recording it complete — proves fresh, not resumed
- log config from the old run is not carried into the new state file (`LogPath`, `NoLogStepIds`)
- the newly written state contains no prior `StepperData`
- the guarded `$Stepper`-removal assertion (the core leak check) is kept; its `Get-Variable` read already uses `-ErrorAction SilentlyContinue` and asserts null, so it does not throw

Test-only change; no product code. 373 passed, 0 failed locally.
